### PR TITLE
fix: entrysheet.editの締め切りタブのクリック範囲・タイトル引き継ぎの修正

### DIFF
--- a/app/Http/Controllers/EntrysheetController.php
+++ b/app/Http/Controllers/EntrysheetController.php
@@ -100,6 +100,7 @@ class EntrysheetController extends Controller implements HasMiddleware
     {
         $companies = Company::where('user_id', Auth::id())->get();
         $presetTitles = [
+            'インターン',
             '夏インターン',
             '秋・冬インターン',
             '長期インターン',
@@ -229,7 +230,7 @@ class EntrysheetController extends Controller implements HasMiddleware
     
         $service = new Google_Service_Calendar($client);
         $event = new Google_Service_Calendar_Event([
-            'summary' => $entrysheet->company->name . ' :ES締切',
+            'summary' => $entrysheet->company->name . ':ES締切',
             'start' => ['date' => $entrysheet->deadline],
             'end' => ['date' => $entrysheet->deadline],
         ]);
@@ -274,7 +275,7 @@ class EntrysheetController extends Controller implements HasMiddleware
             $event = $service->events->get($calendarId, $entrysheet->google_event_id);
     
             // **イベント内容を更新**
-            $event->setSummary($entrysheet->company->name . 'ES締切');
+            $event->setSummary($entrysheet->company->name . ':ES締切');
             $event->setStart(new Google_Service_Calendar_EventDateTime(['date' => $entrysheet->deadline]));
             $event->setEnd(new Google_Service_Calendar_EventDateTime(['date' => $entrysheet->deadline]));
     

--- a/resources/views/entrysheet/edit.blade.php
+++ b/resources/views/entrysheet/edit.blade.php
@@ -28,7 +28,7 @@
                             <select name="title" id="title" class="w-full border-gray-300 rounded-[12px] focus:ring-blue-500 focus:border-blue-500" required>
                                 <option value="">タイトルを選択</option>
                                 @foreach ($presetTitles as $title)
-                                    <option value="{{ $title }}">{{ $title }}</option>
+                                    <option value="{{ $title }}" {{ $entrysheet->title == $title ? 'selected' : '' }}>{{ $title }}</option>
                                 @endforeach
                             </select>
                         </div>
@@ -45,14 +45,16 @@
                         </div>
 
                         <!-- 締切日 -->
-                        <div class="mb-5">
+                        <div class="mb-4">
                             <label for="deadline" class="block text-gray-700 font-bold mb-2">締切日</label>
-                            <input type="date" name="deadline" id="deadline" 
-                                value="{{ old('deadline', $entrysheet->deadline ? substr($entrysheet->deadline, 0, 10) : '') }}"
-                                class="w-full border-gray-300 rounded-[12px] focus:ring-blue-500 focus:border-blue-500 px-4 py-2">
+                            <div id="deadline-wrapper" class="relative flex items-center border border-gray-300 rounded-[12px] focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-blue-500 cursor-pointer">
+                                <input type="date" name="deadline" id="deadline" 
+                                    value="{{ old('deadline', $entrysheet->deadline ? substr($entrysheet->deadline, 0, 10) : '') }}"
+                                    class="pl-4 pr-4 py-2 w-full rounded-[12px] focus:ring-blue-500 focus:border-blue-500 appearance-none">
+                            </div>
                         </div>
 
-                        <!-- 所属企業 -->
+                        <!-- 企業 -->
                         <div class="mb-5">
                             <label for="company_id" class="block text-gray-700 font-bold mb-2">企業</label>
                             <select name="company_id" id="company_id" class="w-full border-gray-300 rounded-[12px] focus:ring-blue-500 focus:border-blue-500 px-4 py-2">
@@ -92,3 +94,9 @@
         </div>
     </div>
 </x-app-layout>
+
+<script>
+    document.getElementById('deadline-wrapper').addEventListener('click', function() {
+        document.getElementById('deadline').showPicker();
+    });
+</script>


### PR DESCRIPTION
- entrysheet.editを修正
    - 締切タブのどこを押してもカレンダーが表示されるように修正
    - タイトルが更新前の引き継がれずに再度選択するバグを修正