### PR TITLE
fix: ES登録・編集画面でのカレンダーの表示ロジックを修正

### DIFF
--- a/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef} from "react";
 import { useForm } from "@inertiajs/react";
 import AppLayout from "@/Layouts/AppLayout";
 
@@ -9,6 +9,17 @@ export default function CreateForm({ industries, company: selectedCompany, prese
     deadline: "",
     questions: [""],
   });
+
+  const dateInputRef = useRef(null);
+  const handleDeadlineInputClick = () => {
+  if (dateInputRef.current) {
+    try {
+      dateInputRef.current.showPicker();
+    } catch (error) {
+      console.error("カレンダーの表示に失敗しました:", error);
+    }
+  }
+};
 
   const addQuestion = () => {
     setData("questions", [...data.questions, ""]);
@@ -93,11 +104,13 @@ export default function CreateForm({ industries, company: selectedCompany, prese
           <div className="mb-4">
             <label className="block text-gray-700 font-bold mb-2">締切日</label>
             <input
+              ref={dateInputRef}
               type="date"
               name="deadline"
               value={data.deadline}
               onChange={(e) => setData("deadline", e.target.value)}
-              className="w-full border-gray-300 rounded-[12px] px-4 py-2"
+              onClick={handleDeadlineInputClick}
+              className="w-full border-gray-300 rounded-[12px] px-4 py-2 cursor-pointer"
             />
             {errors.deadline && <div className="text-red-500 text-sm">{errors.deadline}</div>}
           </div>

--- a/resources/js/Pages/App/Entrysheet/Edit/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Edit/index.jsx
@@ -1,3 +1,4 @@
+import React, { useState, useRef } from "react";
 import AppLayout from "@/Layouts/AppLayout";
 import { useForm, Link } from "@inertiajs/react";
 import { icons } from "@/Utils/icons";
@@ -9,6 +10,17 @@ export default function Edit({ entrysheet, presetTitles, companies, errors }) {
         deadline: entrysheet.deadline ? entrysheet.deadline.substring(0, 10) : "",
         company_id: entrysheet.company_id,
     });
+    const dateInputRef = useRef(null);
+    const handleDeadlineInputClick = () => {
+        if (dateInputRef.current) {
+            try {
+            dateInputRef.current.showPicker();
+            } catch (error) {
+            console.error("カレンダーの表示に失敗しました:", error);
+            }
+        }
+    };
+
 
     const handleChange = (event) => {
         setData(event.target.name, event.target.value);
@@ -93,12 +105,14 @@ export default function Edit({ entrysheet, presetTitles, companies, errors }) {
                                     </label>
                                     <div className="relative flex items-center border border-gray-300 rounded-[12px]">
                                         <input
+                                            ref={dateInputRef}
                                             type="date"
                                             name="deadline"
                                             id="deadline"
                                             value={data.deadline}
                                             onChange={handleChange}
-                                            className="pl-4 pr-4 py-2 w-full rounded-[12px] appearance-none"
+                                            onClick={handleDeadlineInputClick}
+                                            className="pl-4 pr-4 py-2 w-full rounded-[12px] appearance-none cursor-pointer"
                                         />
                                     </div>
                                 </div>


### PR DESCRIPTION
useRefを使用してタブ内でのクリックでカレンダーを表示できるように修正
```
const dateInputRef = useRef(null);
    const handleDeadlineInputClick = () => {
        if (dateInputRef.current) {
            try {
            dateInputRef.current.showPicker();
            } catch (error) {
            console.error("カレンダーの表示に失敗しました:", error);
            }
        }
    };
```