### PR TITLE
fix: ページタブの表示名を修正

### DIFF
--- a/resources/js/Pages/App/Dashboard/index.jsx
+++ b/resources/js/Pages/App/Dashboard/index.jsx
@@ -6,7 +6,7 @@ import AppLayout from "@/Layouts/AppLayout";
 
 export default function Dashboard({ industries, contents, entrysheets, industriesWithCompanies }) {
     return (
-        <AppLayout title="Home">
+        <AppLayout title="ホーム">
             <div className="min-h-screen">
                 <div className="flex">
                     <IndustryList

--- a/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef} from "react";
 import { useForm } from "@inertiajs/react";
 import AppLayout from "@/Layouts/AppLayout";
 import { icons } from "@/Utils/icons";
+import { Head } from "@inertiajs/react";
 
 export default function CreateForm({ industries, company: selectedCompany, presetTitles }) {
   const { data, setData, post, processing, errors } = useForm({
@@ -37,7 +38,9 @@ export default function CreateForm({ industries, company: selectedCompany, prese
   };
 
   return (
+    
       <div className="max-w-4xl mx-auto py-12 px-6">
+        <Head title="ES作成" />
         <h2 className="text-2xl font-bold text-gray-800 mb-6">エントリーシートを作成</h2>
 
         {Object.keys(errors).length > 0 && (

--- a/resources/js/Pages/App/Entrysheet/Edit/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Edit/index.jsx
@@ -38,7 +38,7 @@ export default function Edit({ entrysheet, presetTitles, companies, errors }) {
     };
 
     return (
-        <AppLayout title="エントリーシートを編集">
+        <AppLayout title="ESを編集">
             <div className="py-12">
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden rounded-[12px] border">

--- a/resources/js/Pages/App/Entrysheet/Show/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Show/index.jsx
@@ -375,4 +375,4 @@ export default function Show() {
   );
 }
 
-Show.layout = (page) => <AppLayout title="エントリーシート詳細">{page}</AppLayout>;
+Show.layout = (page) => <AppLayout title="ES詳細">{page}</AppLayout>;

--- a/resources/js/Pages/Auth/Login/index.jsx
+++ b/resources/js/Pages/Auth/Login/index.jsx
@@ -18,11 +18,10 @@ export default function Login() {
 
     return (
         <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100">
+            <Head title="ログイン" />
             <a href="/" className="absolute top-6 left-8 text-4xl font-bold text-black">
                 estion.
             </a>
-            
-            <Head title="ログイン" />
 
             <div className="w-full max-w-lg mt-6 px-8 py-8 bg-white border rounded-[12px]">
                 <h2 className="text-2xl font-bold text-gray-800 text-center mb-4">ログイン</h2>

--- a/resources/js/Pages/Guest/index.jsx
+++ b/resources/js/Pages/Guest/index.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import NavBar from "@/Pages/Guest/components/NavBar";
 import Footer from "@/Components/Footer";
+import { Head } from "@inertiajs/react";
 
 export default function Guest() {
     return (
@@ -8,6 +9,7 @@ export default function Guest() {
             className="min-h-screen flex flex-col bg-cover bg-center bg-no-repeat"
             style={{ backgroundImage: "url('/image/front/paper.png')" }}
         >
+            <Head title="ES管理" />
             <NavBar />
             <div className="flex-grow">
                 <div className="absolute bottom-1/3 sm:bottom-[38%] md:bottom-[40%] left-16 sm:left-32 md:left-48 lg:left-56">

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -11,7 +11,7 @@ const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 // ②Pagesフォルダ内のjsxファイルをページコンポーネントとして動的に読み込む
 // ③elをにAppをリアクトでレンダリング
 createInertiaApp({
-    title: (title) => `${title} - ${appName}`,
+    title: (title) => `${title} | estion.`,
     resolve: (name) =>
         resolvePageComponent(
             `./Pages/${name}.jsx`,


### PR DESCRIPTION
ブラウザのタブに表示されるページ名を、各コンテンツ内容に即した適切なタイトルに修正しました。