### PR TITLE
fix: フッターのコピーライト表示を控えめに変更

### DIFF
--- a/resources/js/Components/Footer.jsx
+++ b/resources/js/Components/Footer.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Footer() {
     return (
-        <footer className="bg-gray-800 text-white text-center py-4">
+        <footer className="text-xs text-black text-center py-4">
             <p>&copy; {new Date().getFullYear()} estion. All rights reserved.</p>
         </footer>
     );


### PR DESCRIPTION
#### 変更内容
- コピーライトの背景を削除
- 文字の大きさを`text-sm`に変更