### PR TITLE
fix: 企業削除後のリダイレクトの404エラーを修正

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -127,10 +127,12 @@ class CompanyController extends Controller implements HasMiddleware
         try {
             // もし `deleted_at` カラムがある場合は `forceDelete()` で物理削除
             $company->forceDelete();
-
             DB::commit();
+            return redirect()->route('company')->with('message', '企業情報が削除されました。');
+
         } catch (\Exception $e) {
             DB::rollBack();
+            return redirect()->back()->with('error', '企業の削除に失敗しました。');
         }
     }
 


### PR DESCRIPTION
#### 修正点
- `CompanyController@destroy`メソッドにおいて、企業削除成功後に企業一覧ページへリダイレクトするように変更しました。