### PR TITLE
fix: 面接画面のリロード時のリダイレクトを修正

### DIFF
--- a/app/Http/Controllers/GeminiController.php
+++ b/app/Http/Controllers/GeminiController.php
@@ -16,113 +16,166 @@ use Illuminate\Support\Facades\Log;
 class GeminiController extends Controller implements HasMiddleware
 {
     public function index(Request $request)
-    {        
-        $entrysheet = EntrySheet::findOrFail($request->input('entry_sheet_id'));
-        $content = Content::findOrFail($request->input('content_id'));
-
-        $question = $content->question;
-        $answer = $content->answer;
+    {
+        $entrysheetId = $request->input('entry_sheet_id');
+        $contentId = $request->input('content_id');
         $interviewRequest = $request->input('interview_request', '');
 
-        $results = $this->execute($question, $answer, $interviewRequest);
+        $entrysheet = null;
+        $content = null;
+        $questions = [];
 
-        if (!is_array($results) || empty($results)) {
-            return redirect()->route('entrysheet.show', ['entrysheet' => $entrysheet->id])
-                ->with('error', '面接質問を取得できませんでした。もう一度試してください。');
+        // POSTリクエストの場合、新しい面接を開始
+        if ($request->isMethod('post')) {
+            $entrysheet = EntrySheet::findOrFail($entrysheetId);
+            $content = Content::findOrFail($contentId);
+
+            $questionText = $content->question;
+            $answerText = $content->answer;
+
+            $questions = $this->execute($questionText, $answerText, $interviewRequest);
+
+            if (!is_array($questions) || empty($questions)) {
+                return redirect()->route('entrysheet.show', ['entrysheet' => $entrysheet->id])
+                    ->with('error', '面接質問を取得できませんでした。もう一度試してください。');
+            }
+
+            // 生成された質問をセッションに保存
+            $request->session()->put('interview_questions', $questions);
+            $request->session()->put('current_entrysheet_id', $entrysheet->id);
+            $request->session()->put('current_content_id', $content->id);
+
+        } else { // GETリクエストの場合、セッションからデータを取得
+            $questions = $request->session()->get('interview_questions', []);
+            $entrysheetId = $request->session()->get('current_entrysheet_id');
+            $contentId = $request->session()->get('current_content_id');
+
+            if ($entrysheetId && $contentId) {
+                $entrysheet = EntrySheet::find($entrysheetId);
+                $content = Content::find($contentId);
+            }
+
+            if (empty($questions) || !$entrysheet || !$content) {
+                // セッションにデータがない、または無効な場合はダッシュボードにリダイレクト
+                return redirect()->route('dashboard')
+                    ->with('error', '面接セッションが見つかりませんでした。再度面接を開始してください。');
+            }
         }
 
         return Inertia::render('App/Interview/InterviewResult/index', [
             'entrysheet' => $entrysheet,
             'content' => $content,
-            'results' => $results,
+            'results' => $questions,
         ]);
     }
 
     public function index_analysis(Request $request)
     {
-        $analysis = Analysis::findOrFail($request->input('analysis_id'));
-
-        $question = $analysis->question;
-        $answer = $analysis->answer;
+        $analysisId = $request->input('analysis_id');
         $interviewRequest = $request->input('interview_request', '');
 
-        $result = $this->execute($question, $answer, $interviewRequest);
-        $questions = $result;
+        $analysis = null;
+        $questions = [];
 
-        if (!is_array($result) || empty($result)) {
-            return redirect()->route('analysis.index')
-                ->with('error', '面接質問を取得できませんでした。もう一度試してください。');
+        if ($request->isMethod('post')) {
+            $analysis = Analysis::findOrFail($analysisId);
+
+            $questionText = $analysis->question;
+            $answerText = $analysis->answer;
+
+            $questions = $this->execute($questionText, $answerText, $interviewRequest);
+
+            if (!is_array($questions) || empty($questions)) {
+                return redirect()->route('analysis.index')
+                    ->with('error', '面接質問を取得できませんでした。もう一度試してください。');
+            }
+            // 生成された質問をセッションに保存
+            $request->session()->put('interview_questions_analysis', $questions);
+            $request->session()->put('current_analysis_id', $analysis->id);
+
+        } else {
+            $questions = $request->session()->get('interview_questions_analysis', []);
+            $analysisId = $request->session()->get('current_analysis_id');
+
+            if ($analysisId) {
+                $analysis = Analysis::find($analysisId);
+            }
+
+            if (empty($questions) || !$analysis) {
+                return redirect()->route('analysis.index')
+                    ->with('error', '面接セッションが見つかりませんでした。再度面接を開始してください。');
+            }
         }
 
         return view('interview.index_analysis', compact('analysis', 'questions'));
     }
 
     public function execute($question, $answer, $interviewRequest = '')
-{
-    $instruction = "あなたは優秀な新卒採用の面接官です。\n"
-        . "入力は新卒学生が提出したエントリーシートの質問と回答です。\n"
-        . "回答に対して深堀りの質問を5つ、JSON配列形式の文字列で出力してください。\n"
-        . "指示詞（「この」「その」など）は使用しないでください。\n"
-        . "出力は **必ず** JSON配列文字列 **のみ** としてください。他の文字、記号、Markdownのコードブロックマーカー（例: ```json）、説明文は一切含めないでください。\n"
-        . "文字列は `[` で始まり、`]` で終わる必要があります。\n"
-        . "他の情報は一切含めないでください。\n"
-        . "以下の例に厳密に従ってください。\n\n"
-        . "### **出力例:**\n"
-        . "[\"あなたの強みは何ですか？\", \"学生時代に最も力を入れたことは何ですか？\", \"経験から何を学びましたか？\", \"なぜ弊社を志望するのですか？\", \"当社のどの事業に興味がありますか？\"]\n"
-        . "\n"
-        . "この形式以外の回答をしてはいけません。";
+    {
+        $instruction = "あなたは優秀な新卒採用の面接官です。\n"
+            . "入力は新卒学生が提出したエントリーシートの質問と回答です。\n"
+            . "回答に対して深堀りの質問を5つ、JSON配列形式の文字列で出力してください。\n"
+            . "指示詞（「この」「その」など）は使用しないでください。\n"
+            . "出力は **必ず** JSON配列文字列 **のみ** としてください。他の文字、記号、Markdownのコードブロックマーカー（例: ```json）、説明文は一切含めないでください。\n"
+            . "文字列は `[` で始まり、`]` で終わる必要があります。\n"
+            . "他の情報は一切含めないでください。\n"
+            . "以下の例に厳密に従ってください。\n\n"
+            . "### **出力例:**\n"
+            . "[\"あなたの強みは何ですか？\", \"学生時代に最も力を入れたことは何ですか？\", \"経験から何を学びましたか？\", \"なぜ弊社を志望するのですか？\", \"当社のどの事業に興味がありますか？\"]\n"
+            . "\n"
+            . "この形式以外の回答をしてはいけません。";
 
-    if (!empty($interviewRequest)) {
-        $instruction .= "\n\n【追加指示】\n"
-            . "以下のリクエストを考慮して質問を生成してください。\n"
-            . "リクエスト内容: \"$interviewRequest\"";
-    }
-
-    $toGeminiCommand = "{$instruction}\n\n質問:\n{$question}\n\n回答:\n{$answer}";
-
-    $response = Gemini::generativeModel(model: 'gemini-2.0-flash')->generateContent($toGeminiCommand);
-    $rawResult = $response ? $response->text() : null;
-
-    if ($rawResult === null) {
-        return [];
-    }
-
-    $cleanedResult = preg_replace('/^```(?:json|php)?\s*|\s*```$/s', '', $rawResult);
-    $cleanedResult = trim($cleanedResult);
-
-    if (substr($cleanedResult, 0, 3) === '"""' && substr($cleanedResult, -3) === '"""') {
-        $cleanedResult = substr($cleanedResult, 3, -3);
-        $cleanedResult = trim($cleanedResult);
-    }
-
-    else if (substr($cleanedResult, 0, 1) === '"' && substr($cleanedResult, -1) === '"') {
-        $tempDecoded = json_decode($cleanedResult, true);
-        if (json_last_error() === JSON_ERROR_NONE && is_string($tempDecoded)) {
-            $nestedJson = json_decode($tempDecoded, true);
-            if (json_last_error() === JSON_ERROR_NONE && is_array($nestedJson)) {
-                $cleanedResult = $tempDecoded;
-            }
-        } else if (json_last_error() !== JSON_ERROR_NONE) {
-            $cleanedResult = trim($cleanedResult, '"');
+        if (!empty($interviewRequest)) {
+            $instruction .= "\n\n【追加指示】\n"
+                . "以下のリクエストを考慮して質問を生成してください。\n"
+                . "リクエスト内容: \"$interviewRequest\"";
         }
-    }
 
-    $decodedArray = json_decode($cleanedResult, true);
+        $toGeminiCommand = "{$instruction}\n\n質問:\n{$question}\n\n回答:\n{$answer}";
 
-    if (json_last_error() !== JSON_ERROR_NONE) {
-        if (preg_match('/(\[.*\])/s', $cleanedResult, $matches)) {
-            $jsonCandidate = $matches[1];
-            $decodedArray = json_decode($jsonCandidate, true);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                return [];
-            }
-        } else {
+        $response = Gemini::generativeModel(model: 'gemini-2.0-flash')->generateContent($toGeminiCommand);
+        $rawResult = $response ? $response->text() : null;
+
+        if ($rawResult === null) {
             return [];
         }
+
+        $cleanedResult = preg_replace('/^```(?:json|php)?\s*|\s*```$/s', '', $rawResult);
+        $cleanedResult = trim($cleanedResult);
+
+        if (substr($cleanedResult, 0, 3) === '"""' && substr($cleanedResult, -3) === '"""') {
+            $cleanedResult = substr($cleanedResult, 3, -3);
+            $cleanedResult = trim($cleanedResult);
+        }
+
+        else if (substr($cleanedResult, 0, 1) === '"' && substr($cleanedResult, -1) === '"') {
+            $tempDecoded = json_decode($cleanedResult, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_string($tempDecoded)) {
+                $nestedJson = json_decode($tempDecoded, true);
+                if (json_last_error() === JSON_ERROR_NONE && is_array($nestedJson)) {
+                    $cleanedResult = $tempDecoded;
+                }
+            } else if (json_last_error() !== JSON_ERROR_NONE) {
+                $cleanedResult = trim($cleanedResult, '"');
+            }
+        }
+
+        $decodedArray = json_decode($cleanedResult, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            if (preg_match('/(\[.*\])/s', $cleanedResult, $matches)) {
+                $jsonCandidate = $matches[1];
+                $decodedArray = json_decode($jsonCandidate, true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    return [];
+                }
+            } else {
+                return [];
+            }
+        }
+
+        return is_array($decodedArray) ? $decodedArray : [];
     }
-    
-    return is_array($decodedArray) ? $decodedArray : [];
-}
 
     public static function middleware(): array
     {
@@ -131,7 +184,7 @@ class GeminiController extends Controller implements HasMiddleware
             'verified'
         ];
     }
-    
+
     public function showExpectedES(EntrySheet $entrysheet, Content $content)
     {
         return Inertia::render('App/Interview/ExpectedEs/index', [

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -71,7 +71,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // GeminiAPI
     // Route::get('/entrysheet/{entrysheet}/interview/{content}', [GeminiController::class, 'index'])->name('interview.index');
-    Route::post('/interview/start', [GeminiController::class, 'index'])->name('interview.start');
+    // Route::post('/interview/start', [GeminiController::class, 'index'])->name('interview.start');
+    Route::match(['get', 'post'], '/interview/start', [GeminiController::class, 'index'])->name('interview.start');
     Route::post('/interview', [GeminiController::class, 'execute'])->name('interview.execute');
     Route::get('/interview/{entrysheet}/{content}/expected', [GeminiController::class, 'showExpectedES'])->name('interview.expected');
     


### PR DESCRIPTION
feat(interview): 面接画面のリロード時のリダイレクトを修正

面接機能において、面接開始後にページをリロードすると
「The GET method is not supported for route interview/start. Supported methods: POST.」
というエラーが発生する問題を修正した

原因:
- `interview/start` ルートがPOSTメソッドのみをサポートしていたため、ブラウザのリロード（GETリクエスト）時にエラーが発生していた。

修正内容:
- `routes/dashboard.php` の `interview/start` ルートをGET/POST両方に対応。
- `GeminiController` の `index` メソッドにおいて、POSTリクエストで生成された面接質問をセッションに保存するように変更した。
- GETリクエストで `interview/start` にアクセスされた場合、セッションから保存された質問データを読み込み、面接画面を再構築するようにした。
- セッションに面接データがない場合は、適切なエラーメッセージと共にダッシュボードにリダイレクトするようにした。

これにより、ユーザーが面接中にページをリロードしても、中断することなく前回の面接セッションを継続可能。