### PR TITLE
fix: モバイル版ダッシュボードのレイアウト崩れを修正

### DIFF
--- a/resources/js/Pages/App/Dashboard/components/ContentList/index.jsx
+++ b/resources/js/Pages/App/Dashboard/components/ContentList/index.jsx
@@ -2,12 +2,12 @@ import { router } from '@inertiajs/react';
 
 export default function ContentList({ contents }) {
   return (
-    <div className="mx-auto max-w-3xl">
+    <div className="flex flex-col items-center">
       <p className="mb-4 mt-10 text-center font-bold md:mt-0">最近の更新</p>
       {contents.length === 0 ? (
         <p className="text-center text-gray-600">まだコンテンツがありません。</p>
       ) : (
-        <div className>
+        <div className="mx-auto max-w-3xl">
           {contents.map((content) => (
             <div
               key={content.id}


### PR DESCRIPTION
**デプロイ環境でダッシュボードのレイアウトが崩れるバグを修正**

以下参照

- ローカル環境
<img width="706" height="917" alt="スクリーンショット 2025-08-09 13 31 54" src="https://github.com/user-attachments/assets/182ade2f-6f85-4a1d-9774-05803ee34abc" />

- デプロイ環境
<img width="707" height="918" alt="スクリーンショット 2025-08-09 13 31 37" src="https://github.com/user-attachments/assets/f9cca6d6-c6fa-4f63-94a5-946bd5259c4b" />

