### PR TITLE
fix: ReactのHTML属性名規則に修正（crossOrigin・rel追加）

### DIFF
--- a/resources/js/Layouts/AppLayout.jsx
+++ b/resources/js/Layouts/AppLayout.jsx
@@ -25,7 +25,7 @@ export default function AppLayout({ children, title }) {
           <script
             async
             src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-            crossorigin="anonymous"
+            crossOrigin="anonymous"
           ></script>
         </Head>
 

--- a/resources/js/Pages/App/Agreement/index.jsx
+++ b/resources/js/Pages/App/Agreement/index.jsx
@@ -14,7 +14,7 @@ export default function Agreement() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
 

--- a/resources/js/Pages/App/Company/Create/index.jsx
+++ b/resources/js/Pages/App/Company/Create/index.jsx
@@ -27,7 +27,7 @@ const CreateCompany = ({ industries }) => {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="mx-auto max-w-4xl px-6 py-12">

--- a/resources/js/Pages/App/Company/Edit/index.jsx
+++ b/resources/js/Pages/App/Company/Edit/index.jsx
@@ -34,7 +34,7 @@ export default function Edit({ company, industries }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="mx-auto max-w-4xl px-6 py-12">

--- a/resources/js/Pages/App/Company/Index/index.jsx
+++ b/resources/js/Pages/App/Company/Index/index.jsx
@@ -36,7 +36,7 @@ export default function Company() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="mx-auto max-w-7xl py-12 sm:px-6 lg:px-8">

--- a/resources/js/Pages/App/Company/Show/index.jsx
+++ b/resources/js/Pages/App/Company/Show/index.jsx
@@ -19,7 +19,7 @@ export default function Show({ company }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="mx-auto max-w-7xl py-12">

--- a/resources/js/Pages/App/Dashboard/index.jsx
+++ b/resources/js/Pages/App/Dashboard/index.jsx
@@ -17,7 +17,7 @@ export default function Dashboard({ industries, contents, entrysheets, industrie
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="flex h-screen md:mt-10">

--- a/resources/js/Pages/App/Entrysheet/Create/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/index.jsx
@@ -20,7 +20,7 @@ export default function Create({ industries, companies: selectedCompanies, prese
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       {!hasCompanies ? (

--- a/resources/js/Pages/App/Industry/index.jsx
+++ b/resources/js/Pages/App/Industry/index.jsx
@@ -15,7 +15,7 @@ export default function index({ industries, industriesWithCompanies }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="pt-10">

--- a/resources/js/Pages/App/Policy/index.jsx
+++ b/resources/js/Pages/App/Policy/index.jsx
@@ -14,7 +14,7 @@ export default function Policy() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
 

--- a/resources/js/Pages/App/components/NavBar/UserDropDown/index.jsx
+++ b/resources/js/Pages/App/components/NavBar/UserDropDown/index.jsx
@@ -60,7 +60,7 @@ export default function UserDropDown() {
           <a
             href="https://docs.google.com/forms/d/1sZsxsi5FqdiS35YW2CVzQ4CANyljnbjt2K9urmRomHE/edit?pli=1"
             className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-            target="_blank"
+            target="_blank" rel="noreferrer"
           >
             お問い合わせ
           </a>

--- a/resources/js/Pages/Auth/Login/index.jsx
+++ b/resources/js/Pages/Auth/Login/index.jsx
@@ -28,7 +28,7 @@ export default function Login() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
 

--- a/resources/js/Pages/Auth/Register/index.jsx
+++ b/resources/js/Pages/Auth/Register/index.jsx
@@ -28,7 +28,7 @@ export default function Register() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
 

--- a/resources/js/Pages/Auth/ResetPassword.jsx
+++ b/resources/js/Pages/Auth/ResetPassword.jsx
@@ -32,7 +32,7 @@ export default function ResetPassword({ token, email }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
 

--- a/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
+++ b/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
@@ -6,7 +6,7 @@ export default function NavLinks() {
       <a
         href="https://docs.google.com/forms/d/1sZsxsi5FqdiS35YW2CVzQ4CANyljnbjt2K9urmRomHE/edit?pli=1"
         className="text-black transition hover:text-gray-300"
-        target="_blank"
+        target="_blank" rel="noreferrer"
       >
         お問い合わせ
       </a>

--- a/resources/js/Pages/Guest/index.jsx
+++ b/resources/js/Pages/Guest/index.jsx
@@ -23,7 +23,7 @@ export default function Guest() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
 

--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -14,8 +14,11 @@ export default function Edit({ mustVerifyEmail, status }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
+
+
+        
       </Head>
 
       <div className="py-10">


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか、なぜ必要かを簡潔に書く -->
- crossorigin → crossOrigin に修正（react/no-unknown-property）
- target="_blank" に rel="noreferrer" を追加（react/jsx-no-target-blank）

