### PR TITLE
fix: ESLint設定を更新しgroutaをグローバル変数に追加

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,35 +1,42 @@
-import js from '@eslint/js';
-import reactPlugin from 'eslint-plugin-react';
-import prettierConfig from 'eslint-config-prettier';
-import globals from 'globals';
+import js from "@eslint/js";
+import reactPlugin from "eslint-plugin-react";
+import prettierConfig from "eslint-config-prettier";
+import globals from "globals";
 
 export default [
-  js.configs.recommended,
   {
-    files: ['resources/js/**/*.{js,jsx}'],
-    plugins: {
-      react: reactPlugin,
-    },
+    ignores: ["resources/js/ziggy.js"],
+  },
+  // 標準的なJavaScriptのルール
+  js.configs.recommended,
+  // React用の推奨ルール
+  reactPlugin.configs.flat.recommended,
+  // Prettierと競合するルールをオフにする
+  prettierConfig,
+  {
+    files: ["resources/js/**/*.{js,jsx}"],
     languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
       globals: {
         ...globals.browser,
+        ...globals.node,
+        route: "readonly",
       },
       parserOptions: {
         ecmaFeatures: {
           jsx: true,
         },
-        ecmaVersion: 'latest',
-        sourceType: 'module',
       },
     },
     settings: {
       react: {
-        version: 'detect',
+        version: "detect", // Reactのバージョンを自動検出
       },
     },
     rules: {
-      ...reactPlugin.configs.recommended.rules,
+      "react/react-in-jsx-scope": "off", // import React from 'react' を不要にする
+      "react/prop-types": "off"
     },
   },
-  prettierConfig,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
                 "react-textarea-autosize": "^8.5.9"
             },
             "devDependencies": {
+                "@eslint/js": "^9.39.3",
                 "@headlessui/react": "^2.0.0",
                 "@inertiajs/react": "^2.0.0",
                 "@tailwindcss/forms": "^0.5.3",
@@ -19,6 +20,7 @@
                 "eslint": "^9.39.3",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-react": "^7.37.5",
+                "globals": "^17.3.0",
                 "laravel-vite-plugin": "^1.0",
                 "postcss": "^8.4.31",
                 "prettier": "^3.6.2",
@@ -330,6 +332,16 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@babel/types": {
@@ -3640,13 +3652,16 @@
             }
         },
         "node_modules/globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "version": "17.3.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+            "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globalthis": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "format": "prettier --write 'resources/js/**/*.{js,jsx}'"
     },
     "devDependencies": {
+        "@eslint/js": "^9.39.3",
         "@headlessui/react": "^2.0.0",
         "@inertiajs/react": "^2.0.0",
         "@tailwindcss/forms": "^0.5.3",
@@ -17,10 +18,10 @@
         "autoprefixer": "^10.4.12",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",
-        "@eslint/js": "^9.39.3",
         "eslint": "^9.39.3",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
+        "globals": "^17.3.0",
         "laravel-vite-plugin": "^1.0",
         "postcss": "^8.4.31",
         "prettier": "^3.6.2",


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか、なぜ必要かを簡潔に書く -->
- route をグローバル変数として定義（Ziggy対応）
- 自動生成ファイル ziggy.js を ESLint 対象から除外
- globals パッケージを追加
