### PR TITLE
fix: 未使用の変数・importを削除（no-unused-vars）

### DIFF
--- a/resources/js/Components/Icons/Saveicon.jsx
+++ b/resources/js/Components/Icons/Saveicon.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function Saveicon({ className = 'w-4 h-4 text-current opacity-50' }) {
+export default function Saveicon() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -9,10 +9,10 @@ export default function Saveicon({ className = 'w-4 h-4 text-current opacity-50'
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      class="lucide lucide-arrow-down-to-line-icon lucide-arrow-down-to-line"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-arrow-down-to-line-icon lucide-arrow-down-to-line"
     >
       <path d="M12 17V3" />
       <path d="m6 11 6 6 6-6" />

--- a/resources/js/Pages/App/Company/Index/CompanyActionButtons/index.jsx
+++ b/resources/js/Pages/App/Company/Index/CompanyActionButtons/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from '@inertiajs/react';
 import AddCompanyicon from '@/Components/Icons/AddCompanyicon';
-import { icons } from '@/Utils/icons';
 export default function CompanyActionButtons() {
   return (
     <div className="mb-4 flex items-center justify-between">

--- a/resources/js/Pages/App/Company/Index/CompanyList/CompanyListItem/index.jsx
+++ b/resources/js/Pages/App/Company/Index/CompanyList/CompanyListItem/index.jsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react';
-import { router } from '@inertiajs/react';
+import React from 'react';
 import { icons } from '@/Utils/icons';
 
 export default function CompanyListItem({
@@ -7,7 +6,6 @@ export default function CompanyListItem({
   onCompanyClick,
   onCompanyRightClick,
   onDelete,
-  selectedCompanyId,
 }) {
   return (
     <div

--- a/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
@@ -1,6 +1,5 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import { useForm } from '@inertiajs/react';
-import AppLayout from '@/Layouts/AppLayout';
 import { icons } from '@/Utils/icons';
 import { Head } from '@inertiajs/react';
 
@@ -43,7 +42,7 @@ export default function CreateForm({ industries, company: selectedCompany, prese
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <h2 className="mb-6 text-2xl font-bold text-gray-800">エントリーシートを作成</h2>

--- a/resources/js/Pages/App/Entrysheet/Create/CreateWithCompany.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/CreateWithCompany.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import AppLayout from '@/Layouts/AppLayout';
 import CreateForm from './CreateForm';
-import { Head, Link } from '@inertiajs/react';
 //通常のES作成と引数が違うからとりあえずファイルを分けて修正
 //もっといいやり方があると思います。
 export default function CreateWithCompany({ industries, company, presetTitles }) {

--- a/resources/js/Pages/App/Entrysheet/Edit/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Edit/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import AppLayout from '@/Layouts/AppLayout';
 import { Head, useForm, Link, router } from '@inertiajs/react';
 import { icons } from '@/Utils/icons';
@@ -48,7 +48,7 @@ export default function Edit({ entrysheet, presetTitles, companies, errors }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="py-12">

--- a/resources/js/Pages/App/Entrysheet/Index/EntryseetFilterModal/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Index/EntryseetFilterModal/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { icons } from '@/Utils/icons';
 
 export default function EntrysheetFilterModal({ showFilter, setShowFilter, filters }) {
   return (

--- a/resources/js/Pages/App/Entrysheet/Index/EntrysheetActionbuttons/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Index/EntrysheetActionbuttons/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from '@inertiajs/react';
 import { icons } from '@/Utils/icons';
 
-export default function EntrysheetActionButtons({ setShowFilter }) {
+export default function EntrysheetActionButtons() {
   return (
     <div className="mb-4 flex items-center justify-between">
       <Link

--- a/resources/js/Pages/App/Entrysheet/Index/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Index/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import AppLayout from '@/Layouts/AppLayout';
 import { usePage } from '@inertiajs/react';
 import EntrysheetList from './EntrysheetList';
@@ -6,8 +6,7 @@ import EntrysheetActionButtons from './EntrysheetActionbuttons';
 import { Head, router } from '@inertiajs/react';
 
 export default function Entrysheet() {
-  const { entrysheets, filters } = usePage().props;
-  const [showFilter, setShowFilter] = useState(false);
+  const { entrysheets } = usePage().props;
 
   const handleDelete = (id) => {
     if (!confirm('このエントリーシートを削除しますか？')) return;
@@ -28,14 +27,14 @@ export default function Entrysheet() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="py-12">
         <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
           <div className="relative overflow-hidden rounded-[12px] bg-white shadow-md">
             <div className="p-6 text-gray-900">
-              <EntrysheetActionButtons setShowFilter={setShowFilter} />
+              <EntrysheetActionButtons />
               <h2 className="mt-6 text-xl font-bold">登録したエントリーシート</h2>
 
               {entrysheets.length === 0 ? (

--- a/resources/js/Pages/App/Entrysheet/Show/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Show/index.jsx
@@ -6,7 +6,7 @@ import { icons } from '@/Utils/icons';
 import formatDate from '@/Utils/formatDate';
 
 export default function Show() {
-  const { entrysheet, errors: pageGlobalErrors } = usePage().props;
+  const { entrysheet } = usePage().props;
   const [newContents, setNewContents] = useState([]);
   const [copiedContentId, setCopiedContentId] = useState(null);
   const [copiedNewItemId, setCopiedNewItemId] = useState(null);
@@ -186,7 +186,7 @@ export default function Show() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="py-12">

--- a/resources/js/Pages/App/Interview/ExpectedEs/index.jsx
+++ b/resources/js/Pages/App/Interview/ExpectedEs/index.jsx
@@ -1,9 +1,9 @@
 import TextareaAutosize from 'react-textarea-autosize';
 import AppLayout from '@/Layouts/AppLayout';
-import { Head, Link, useForm } from '@inertiajs/react';
+import { Head, useForm } from '@inertiajs/react';
 
 export default function ExpectedEs({ entrysheet, content }) {
-  const { data, setData, post, processing, errors, reset } = useForm({
+  const { data, setData, post, processing, errors } = useForm({
     entry_sheet_id: entrysheet?.id ?? '',
     content_id: content?.id ?? '',
     interview_request: '',
@@ -26,7 +26,7 @@ export default function ExpectedEs({ entrysheet, content }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="py-12">

--- a/resources/js/Pages/App/Interview/InterviewResult/index.jsx
+++ b/resources/js/Pages/App/Interview/InterviewResult/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import AppLayout from '@/Layouts/AppLayout';
 import { Head, Link } from '@inertiajs/react';
 import { icons } from '@/Utils/icons';
@@ -6,7 +6,7 @@ import { icons } from '@/Utils/icons';
 export default function InterviewResult({ entrysheet, content, results }) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [showEndMessage, setShowEndMessage] = useState(false);
-  const [showAllQuestions, setShowAllQuestions] = useState(false);
+  const [, setShowAllQuestions] = useState(false);
 
   const questions = results || [];
 
@@ -66,7 +66,7 @@ export default function InterviewResult({ entrysheet, content, results }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="py-12">

--- a/resources/js/Pages/App/Qa/index.jsx
+++ b/resources/js/Pages/App/Qa/index.jsx
@@ -1,4 +1,4 @@
-import { Head, Link } from '@inertiajs/react';
+import { Head } from '@inertiajs/react';
 
 export default function Agreement() {
   return (
@@ -13,7 +13,7 @@ export default function Agreement() {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
 

--- a/resources/js/Pages/App/components/BookmarkCreate/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/App/components/BookmarkCreate/BookmarkIndex/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useForm } from '@inertiajs/react';
+import { useForm } from '@inertiajs/react';
 
 export default function BookmarkIndex({ bookmarks }) {
   const { delete: destroy } = useForm({});
@@ -27,7 +27,7 @@ export default function BookmarkIndex({ bookmarks }) {
                 <a
                   href={bookmark.url}
                   className="block py-1 font-bold text-blue-500 hover:text-blue-800"
-                  target="_blank"
+                  target="_blank" rel="noreferrer"
                 >
                   {bookmark.name}
                 </a>

--- a/resources/js/Pages/App/components/BookmarkCreate/index.jsx
+++ b/resources/js/Pages/App/components/BookmarkCreate/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Head, useForm, Link } from '@inertiajs/react';
-import { icons } from '@/Utils/icons';
+import { Head, useForm } from '@inertiajs/react';
 import AppLayout from '@/Layouts/AppLayout';
 import BookmarkIndex from './BookmarkIndex';
 
@@ -35,7 +34,7 @@ export default function BookmarkCreate({ bookmarks }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       {/* 追加フォームを囲む div で幅を調整 */}

--- a/resources/js/Pages/Guest/components/NavBar/MenuToggle/index.jsx
+++ b/resources/js/Pages/Guest/components/NavBar/MenuToggle/index.jsx
@@ -1,4 +1,4 @@
-export default function MenuToggle({ isMenuOpen, toggleMenu }) {
+export default function MenuToggle({ toggleMenu }) {
   return (
     <div className="mr-3 flex items-center sm:hidden">
       <button

--- a/resources/js/Utils/formatDate.jsx
+++ b/resources/js/Utils/formatDate.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const formatDate = (dateTimeString) => {
   const date = new Date(dateTimeString);
   const year = date.getFullYear();
@@ -12,8 +10,5 @@ const formatDate = (dateTimeString) => {
   return `${year}年${formattedMonth}月${formattedDay}日`;
 };
 
-const MyComponent = ({ createdAt }) => {
-  return <div>作成日: {formatDate(createdAt)}</div>;
-};
 
 export default formatDate;


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか、なぜ必要かを簡潔に書く -->
- 未使用のimport（useState, Link, icons等）を削除
- 未使用の変数・props（filters, showFilter, reset等）を削除
- SVGアイコンコンポーネントの属性名をReact規則に修正