### PR TITLE
fix: JSX内の特殊文字エスケープとデッドコード削除

### DIFF
--- a/resources/js/Pages/App/Entrysheet/Content/Edit/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Content/Edit/index.jsx
@@ -12,9 +12,6 @@ export default function Edit({ content }) {
 
   const handleChange = (event) => {
     setData(event.target.name, event.target.value);
-    if (event.target.name === 'answer') {
-      setCharCount(event.target.value.length);
-    }
   };
 
   const handleSubmit = (e) => {
@@ -38,7 +35,7 @@ export default function Edit({ content }) {
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
-          crossorigin="anonymous"
+          crossOrigin="anonymous"
         ></script>
       </Head>
       <div className="py-12">

--- a/resources/js/Pages/Auth/ConfirmPassword.jsx
+++ b/resources/js/Pages/Auth/ConfirmPassword.jsx
@@ -21,7 +21,7 @@ export default function ConfirmPassword() {
   return (
     <GuestLayout>
       <Head>
-        <title>"Confirm Password"</title>
+        <title>Confirm Password</title>
         <meta name="google-adsense-account" content="ca-pub-9604843985307640" />
       </Head>
 

--- a/resources/js/Pages/Auth/VerifyEmail.jsx
+++ b/resources/js/Pages/Auth/VerifyEmail.jsx
@@ -14,13 +14,13 @@ export default function VerifyEmail({ status }) {
   return (
     <GuestLayout>
       <Head>
-        <title>"Email Verification"</title>
+        <title>Email Verification</title>
         <meta name="google-adsense-account" content="ca-pub-9604843985307640" />
       </Head>
 
       <div className="mb-4 text-sm text-gray-600">
         Thanks for signing up! Before getting started, could you verify your email address by
-        clicking on the link we just emailed to you? If you didn't receive the email, we will gladly
+        clicking on the link we just emailed to you? If you didn&apos;t receive the email, we will gladly
         send you another.
       </div>
 


### PR DESCRIPTION
## 概要
<!-- このPRで何をしたか、なぜ必要かを簡潔に書く -->
- ConfirmPassword / VerifyEmail: <title>内の不要なクォートを削除（react/no-unescaped-entities）
- VerifyEmail: didn't → didn&apos;t に修正
- Entrysheet/Content/Edit: 未定義の setCharCount を呼ぶデッドコードを削除（no-undef）