### PR TITLE
docs: README にコードスタイル規約を追記、CLAUDE.md を更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,10 @@ Laravel + React (Inertia.js) による就活生向けエントリーシート管
 ## Commands
 Claude Codeがスクリプトやテストを実行する際は以下を使用すること。
 - **Backend (Docker)**: 必ず `./vendor/bin/sail` 経由で実行すること (例: `./vendor/bin/sail artisan migrate`, `./vendor/bin/sail artisan test`)
+- **ログ確認**: `./vendor/bin/sail logs -f`
 - **Frontend**: `npm run dev` (Vite), `npm run build`
 - **Code Style/Lint**: 
-  - PHP: `./vendor/bin/pint`
+  - PHP: `./vendor/bin/sail pint`
   - JS/JSX: `npm run lint:fix`, `npm run format`
 
 ## Custom Rules

--- a/README.md
+++ b/README.md
@@ -6,3 +6,22 @@
 
 [**アプリはこちら**](https://estion.jp/)
 &nbsp;
+
+## 規約・フォーマット (Code Style & Lint)
+
+コードの品質を保つため、コミット前に以下のコマンドを実行してフォーマットと静的解析を行ってください。
+
+**PHP (Laravel Pint)**
+
+```bash
+./vendor/bin/sail pint
+```
+**JavaScript / React (ESLint & Prettier)**
+
+ESLintによる静的解析と自動修正とPrettierによるコード整形
+```bash
+npm run lint:fix
+```
+```bash
+npm run format
+```


### PR DESCRIPTION
## 概要
ドキュメントの整備。README にコードスタイル規約のセクションを追加し、CLAUDE.md のコマンドを修正・補完した。

## 変更内容
- `README.md`: PHP (Laravel Pint) および JS/React (ESLint & Prettier) のコマンドを記載したセクションを追加
- `CLAUDE.md`:
  - PHP Lint コマンドを `./vendor/bin/pint` → `./vendor/bin/sail pint` に修正 (Docker 経由に統一)
  - ログ確認コマンド `./vendor/bin/sail logs -f` を追記

## 影響範囲
- ドキュメント変更のみ。アプリケーションコードへの影響なし