### PR TITLE
style: Prettier でフロントエンドコードを整形

### DIFF
--- a/resources/js/Pages/App/components/BookmarkCreate/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/App/components/BookmarkCreate/BookmarkIndex/index.jsx
@@ -27,7 +27,8 @@ export default function BookmarkIndex({ bookmarks }) {
                 <a
                   href={bookmark.url}
                   className="block py-1 font-bold text-blue-500 hover:text-blue-800"
-                  target="_blank" rel="noreferrer"
+                  target="_blank"
+                  rel="noreferrer"
                 >
                   {bookmark.name}
                 </a>

--- a/resources/js/Pages/App/components/NavBar/UserDropDown/index.jsx
+++ b/resources/js/Pages/App/components/NavBar/UserDropDown/index.jsx
@@ -60,7 +60,8 @@ export default function UserDropDown() {
           <a
             href="https://docs.google.com/forms/d/1sZsxsi5FqdiS35YW2CVzQ4CANyljnbjt2K9urmRomHE/edit?pli=1"
             className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-            target="_blank" rel="noreferrer"
+            target="_blank"
+            rel="noreferrer"
           >
             お問い合わせ
           </a>

--- a/resources/js/Pages/Auth/VerifyEmail.jsx
+++ b/resources/js/Pages/Auth/VerifyEmail.jsx
@@ -20,8 +20,8 @@ export default function VerifyEmail({ status }) {
 
       <div className="mb-4 text-sm text-gray-600">
         Thanks for signing up! Before getting started, could you verify your email address by
-        clicking on the link we just emailed to you? If you didn&apos;t receive the email, we will gladly
-        send you another.
+        clicking on the link we just emailed to you? If you didn&apos;t receive the email, we will
+        gladly send you another.
       </div>
 
       {status === 'verification-link-sent' && (

--- a/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
+++ b/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
@@ -6,7 +6,8 @@ export default function NavLinks() {
       <a
         href="https://docs.google.com/forms/d/1sZsxsi5FqdiS35YW2CVzQ4CANyljnbjt2K9urmRomHE/edit?pli=1"
         className="text-black transition hover:text-gray-300"
-        target="_blank" rel="noreferrer"
+        target="_blank"
+        rel="noreferrer"
       >
         お問い合わせ
       </a>

--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -16,9 +16,6 @@ export default function Edit({ mustVerifyEmail, status }) {
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
           crossOrigin="anonymous"
         ></script>
-
-
-        
       </Head>
 
       <div className="py-10">

--- a/resources/js/Utils/formatDate.jsx
+++ b/resources/js/Utils/formatDate.jsx
@@ -10,5 +10,4 @@ const formatDate = (dateTimeString) => {
   return `${year}年${formattedMonth}月${formattedDay}日`;
 };
 
-
 export default formatDate;


### PR DESCRIPTION
## 概要
`npm run format` を実行し、JSX ファイルのコードを Prettier で統一整形。

## 変更内容
- 改行位置・スペースの統一 (6ファイル)
  - `BookmarkCreate/BookmarkIndex/index.jsx`
  - `NavBar/UserDropDown/index.jsx`
  - `Auth/VerifyEmail.jsx`
  - `Guest/components/NavBar/NavLinks/index.jsx`
  - `Profile/Edit.jsx`
  - `Utils/formatDate.jsx`

## 影響範囲
- ロジックの変更なし。Prettier によるフォーマット変更のみ