### PR TITLE
fix: 文字数制限に0未満の値を入力できないよう制限

### DIFF
--- a/resources/js/Pages/App/Entrysheet/Content/Edit/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Content/Edit/index.jsx
@@ -69,6 +69,7 @@ export default function Edit({ content }) {
                     type="number"
                     name="character_limit"
                     id="character_limit"
+                    min="0"
                     value={data.character_limit}
                     onChange={handleChange}
                     className={`w-full rounded-[12px] border-gray-300 px-6 py-3 focus:border-blue-500 focus:ring-blue-500 ${errors.character_limit ? 'border-red-500' : ''}`}


### PR DESCRIPTION
## 概要
設問編集画面の文字数制限フィールドで、0未満の負の値が入力・送信できてしまう問題を修正。

## 変更内容
- `resources/js/Pages/App/Entrysheet/Content/Edit/index.jsx`
  - `<input type="number">` に `min="0"` 属性を追加

## 影響範囲
- バックエンド (`UpdateContentQuestionRequest`) には既に `'min:0'` バリデーションが存在しており、フロント・バック両方で制約が揃った状態になる
- UI の変更のみで、ロジックへの影響なし