### PR TITLE
fix: 全ページのタイトルに｜estion.を統一付与

### DIFF
--- a/resources/js/Layouts/AppLayout.jsx
+++ b/resources/js/Layouts/AppLayout.jsx
@@ -20,7 +20,7 @@ export default function AppLayout({ children, title }) {
 
       <div className="min-h-screen bg-gray-50 pb-10 text-gray-900 md:pt-20">
         <Head>
-          <title>{title ?? 'estion'}</title>
+          <title>{title ? `${title}｜estion.` : 'estion.'}</title>
           <meta name="google-adsense-account" content="ca-pub-9604843985307640" />
           <script
             async

--- a/resources/js/Pages/App/Agreement/index.jsx
+++ b/resources/js/Pages/App/Agreement/index.jsx
@@ -5,7 +5,7 @@ export default function Agreement() {
   return (
     <>
       <Head>
-        <title>利用規約</title>
+        <title>利用規約｜estion.</title>
         <meta
           name="description"
           content="estion.の利用規約です。サービスのご利用にあたってのルールや、免責事項、禁止事項などについて記載しています。"

--- a/resources/js/Pages/App/Company/Create/index.jsx
+++ b/resources/js/Pages/App/Company/Create/index.jsx
@@ -18,7 +18,7 @@ const CreateCompany = ({ industries }) => {
   return (
     <AppLayout>
       <Head>
-        <title>企業登録</title>
+        <title>企業登録｜estion.</title>
         <meta
           name="description"
           content="estion.の企業登録ページです。エントリーする企業を登録することができます。"

--- a/resources/js/Pages/App/Company/Edit/index.jsx
+++ b/resources/js/Pages/App/Company/Edit/index.jsx
@@ -25,7 +25,7 @@ export default function Edit({ company, industries }) {
   return (
     <AppLayout>
       <Head>
-        <title>企業情報編集</title>
+        <title>企業情報編集｜estion.</title>
         <meta
           name="description"
           content="estion.の企業情報編集ページです。登録した企業の情報を編集することができます。"

--- a/resources/js/Pages/App/Company/Index/index.jsx
+++ b/resources/js/Pages/App/Company/Index/index.jsx
@@ -27,7 +27,7 @@ export default function Company() {
   return (
     <AppLayout>
       <Head>
-        <title>企業一覧</title>
+        <title>企業一覧｜estion.</title>
         <meta
           name="description"
           content="estion.の企業一覧ページです。登録した企業をまとめて確認できます。"

--- a/resources/js/Pages/App/Company/Show/index.jsx
+++ b/resources/js/Pages/App/Company/Show/index.jsx
@@ -10,7 +10,7 @@ export default function Show({ company }) {
   return (
     <>
       <Head>
-        <title>企業詳細</title>
+        <title>企業詳細｜estion.</title>
         <meta
           name="description"
           content="estion.の企業詳細ページです。企業の詳細を確認できます。"

--- a/resources/js/Pages/App/Dashboard/index.jsx
+++ b/resources/js/Pages/App/Dashboard/index.jsx
@@ -8,7 +8,7 @@ export default function Dashboard({ industries, contents, entrysheets, industrie
   return (
     <AppLayout>
       <Head>
-        <title>ダッシュボード</title>
+        <title>ダッシュボード｜estion.</title>
         <meta
           name="description"
           content="estion.のダッシュボードです。登録した企業やエントリーシートの進捗状況、就活に役立つ最新コンテンツをまとめて確認できます。"

--- a/resources/js/Pages/App/Entrysheet/Content/Edit/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Content/Edit/index.jsx
@@ -26,7 +26,7 @@ export default function Edit({ content }) {
   return (
     <AppLayout>
       <Head>
-        <title>設問と文字数の編集</title>
+        <title>設問と文字数の編集｜estion.</title>
         <meta
           name="description"
           content="estion.のES詳細編集ページです。登録したESの設問・文字数を編集することができます。"

--- a/resources/js/Pages/App/Entrysheet/Create/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/index.jsx
@@ -11,7 +11,7 @@ export default function Create({ industries, companies: selectedCompanies, prese
   return (
     <AppLayout>
       <Head>
-        <title>ES作成</title>
+        <title>ES作成｜estion.</title>
         <meta
           name="description"
           content="estion.のES作成ページです。応募企業のESを登録することができます。"

--- a/resources/js/Pages/App/Entrysheet/Edit/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Edit/index.jsx
@@ -39,7 +39,7 @@ export default function Edit({ entrysheet, presetTitles, companies, errors }) {
   return (
     <AppLayout>
       <Head>
-        <title>ESを編集</title>
+        <title>ESを編集｜estion.</title>
         <meta
           name="description"
           content="estion.のES編集ページです。登録したエントリーシートの締切を修正することができます。"

--- a/resources/js/Pages/App/Entrysheet/Index/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Index/index.jsx
@@ -18,7 +18,7 @@ export default function Entrysheet() {
   return (
     <AppLayout>
       <Head>
-        <title>ES一覧</title>
+        <title>ES一覧｜estion.</title>
         <meta
           name="description"
           content="estion.のES一覧ページです。登録したエントリーシートの一覧を確認できます。"

--- a/resources/js/Pages/App/Entrysheet/Show/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Show/index.jsx
@@ -177,7 +177,7 @@ export default function Show() {
   return (
     <>
       <Head>
-        <title>ES詳細</title>
+        <title>ES詳細｜estion.</title>
         <meta
           name="description"
           content="estion.のES詳細ページです。登録したエントリーシートの詳細(質問・回答)を確認できます。"

--- a/resources/js/Pages/App/Industry/index.jsx
+++ b/resources/js/Pages/App/Industry/index.jsx
@@ -6,7 +6,7 @@ export default function index({ industries, industriesWithCompanies }) {
   return (
     <AppLayout>
       <Head>
-        <title>業界一覧</title>
+        <title>業界一覧｜estion.</title>
         <meta
           name="description"
           content="estion.の業界一覧ページです。業界ごとに企業を確認することができます。"

--- a/resources/js/Pages/App/Interview/ExpectedEs/index.jsx
+++ b/resources/js/Pages/App/Interview/ExpectedEs/index.jsx
@@ -17,7 +17,7 @@ export default function ExpectedEs({ entrysheet, content }) {
   return (
     <AppLayout>
       <Head>
-        <title>面接内容の確認</title>
+        <title>面接内容の確認｜estion.</title>
         <meta
           name="description"
           content="estion.の面接内容確認ページです。設問に対してリクエストを追加し、面接に進むことができます。"

--- a/resources/js/Pages/App/Interview/InterviewResult/index.jsx
+++ b/resources/js/Pages/App/Interview/InterviewResult/index.jsx
@@ -57,7 +57,7 @@ export default function InterviewResult({ entrysheet, content, results }) {
   return (
     <>
       <Head>
-        <title>面接結果の確認</title>
+        <title>面接結果の確認｜estion.</title>
         <meta
           name="description"
           content="estion.の面接結果確認ページです。設問に対して生成された面接質問を確認することができます。"

--- a/resources/js/Pages/App/Policy/index.jsx
+++ b/resources/js/Pages/App/Policy/index.jsx
@@ -5,7 +5,7 @@ export default function Policy() {
   return (
     <>
       <Head>
-        <title>プライバシーポリシー</title>
+        <title>プライバシーポリシー｜estion.</title>
         <meta
           name="description"
           content="estion.のプライバシーポリシーです。本サービスにおける個人情報の取得、利用、管理についてご説明しています。"

--- a/resources/js/Pages/App/Qa/index.jsx
+++ b/resources/js/Pages/App/Qa/index.jsx
@@ -4,7 +4,7 @@ export default function Agreement() {
   return (
     <>
       <Head>
-        <title>Q&A</title>
+        <title>Q&A｜estion.</title>
         <meta
           name="description"
           content="estion.のQ&Aページです。estion.の使い方やよくある質問を確認することができます。"

--- a/resources/js/Pages/App/components/BookmarkCreate/index.jsx
+++ b/resources/js/Pages/App/components/BookmarkCreate/index.jsx
@@ -25,7 +25,7 @@ export default function BookmarkCreate({ bookmarks }) {
   return (
     <AppLayout>
       <Head>
-        <title>ブックマーク登録</title>
+        <title>ブックマーク登録｜estion.</title>
         <meta
           name="description"
           content="estion.のブックマーク登録ページです。頻繁に利用するサイトURLを登録・削除することができます。"

--- a/resources/js/Pages/Auth/ConfirmPassword.jsx
+++ b/resources/js/Pages/Auth/ConfirmPassword.jsx
@@ -21,7 +21,7 @@ export default function ConfirmPassword() {
   return (
     <GuestLayout>
       <Head>
-        <title>Confirm Password</title>
+        <title>Confirm Password｜estion.</title>
         <meta name="google-adsense-account" content="ca-pub-9604843985307640" />
       </Head>
 

--- a/resources/js/Pages/Auth/ForgotPassword.jsx
+++ b/resources/js/Pages/Auth/ForgotPassword.jsx
@@ -16,7 +16,7 @@ export default function ForgotPassword({ status }) {
   return (
     <>
       <Head>
-        <title>パスワード再設定</title>
+        <title>パスワード再設定｜estion.</title>
         <meta
           name="description"
           content="estion.のパスワード再設定画面です。ご登録のメールアドレスを入力して、パスワード再設定の手続きにお進みください。"

--- a/resources/js/Pages/Auth/Login/index.jsx
+++ b/resources/js/Pages/Auth/Login/index.jsx
@@ -19,7 +19,7 @@ export default function Login() {
   return (
     <>
       <Head>
-        <title>ログイン</title>
+        <title>ログイン｜estion.</title>
         <meta
           name="description"
           content="新卒就活生向けES管理アプリ「estion.」のログイン画面です。ログインして、ESの進捗管理、企業情報、面接練習など、就活を効率化する機能をご利用ください。"

--- a/resources/js/Pages/Auth/Register/index.jsx
+++ b/resources/js/Pages/Auth/Register/index.jsx
@@ -19,7 +19,7 @@ export default function Register() {
   return (
     <>
       <Head>
-        <title>新規登録</title>
+        <title>新規登録｜estion.</title>
         <meta
           name="description"
           content="新卒就活生向けES管理アプリ「estion.」に新規登録して、就活の進捗管理を始めましょう。無料で簡単にアカウントを作成できます。"

--- a/resources/js/Pages/Auth/ResetPassword.jsx
+++ b/resources/js/Pages/Auth/ResetPassword.jsx
@@ -22,7 +22,7 @@ export default function ResetPassword({ token, email }) {
   return (
     <>
       <Head>
-        <title>新しいパスワードを設定</title>
+        <title>新しいパスワードを設定｜estion.</title>
 
         <meta
           name="description"

--- a/resources/js/Pages/Auth/VerifyEmail.jsx
+++ b/resources/js/Pages/Auth/VerifyEmail.jsx
@@ -14,7 +14,7 @@ export default function VerifyEmail({ status }) {
   return (
     <GuestLayout>
       <Head>
-        <title>Email Verification</title>
+        <title>Email Verification｜estion.</title>
         <meta name="google-adsense-account" content="ca-pub-9604843985307640" />
       </Head>
 

--- a/resources/js/Pages/Guest/index.jsx
+++ b/resources/js/Pages/Guest/index.jsx
@@ -14,7 +14,7 @@ export default function Guest() {
   return (
     <>
       <Head>
-        <title>新卒就活生向けES管理アプリ</title>
+        <title>新卒就活生向けES管理アプリ｜estion.</title>
         <meta
           name="description"
           content="新卒就活生向けのエントリーシート（ES）管理アプリestion.(イーション)です。estion.を活用して多種多様な業界・企業のESを効率的に管理しましょう!"

--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -8,7 +8,7 @@ export default function Edit({ mustVerifyEmail, status }) {
   return (
     <AppLayout>
       <Head>
-        <title>プロフィール確認</title>
+        <title>プロフィール確認｜estion.</title>
         <meta name="description" content="プロフィールを確認・修正することができます。" />
         <meta name="google-adsense-account" content="ca-pub-9604843985307640" />
         <script

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -6,7 +6,7 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createRoot } from 'react-dom/client';
 
 createInertiaApp({
-  title: (title) => `${title} - estion.`,
+  title: (title) => `${title}｜estion.`,
   resolve: (name) =>
     resolvePageComponent(`./Pages/${name}.jsx`, import.meta.glob('./Pages/**/*.jsx')),
   setup({ el, App, props }) {


### PR DESCRIPTION
## 概要

全ページのブラウザタブ・検索結果に表示されるタイトルを `ページ名｜estion.` 形式に統一しました。

## 変更内容

- `resources/js/app.jsx`: タイトル区切りを ` - ` から `｜` に変更
- `resources/js/Layouts/AppLayout.jsx`: JSX式のタイトルを `${title}｜estion.` 形式に修正
- `resources/js/Pages/Guest/index.jsx`: タイトルを `新卒就活生向けES管理アプリ｜estion.` に変更
- 上記以外の全24ページ: `<title>xxx</title>` を `<title>xxx｜estion.</title>` に一括変更

## 影響範囲

- 全ページのタブタイトル・検索結果表示に影響
- アプリの動作・UIへの影響なし
- `Entrysheet/Create/CreateForm/index.jsx` は `<Head title="ES作成">` を使用しており `app.jsx` のコールバック経由で `｜estion.` が付与される（二重付与なし）