### PR TITLE
fix: タイトルへのestion.二重付与を修正

### DIFF
--- a/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
@@ -38,7 +38,7 @@ export default function CreateForm({ industries, company: selectedCompany, prese
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-12">
-      <Head title="ES作成">
+      <Head title="ES作成｜estion.">
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"

--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -6,7 +6,7 @@ import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createRoot } from 'react-dom/client';
 
 createInertiaApp({
-  title: (title) => `${title}｜estion.`,
+  title: (title) => title,
   resolve: (name) =>
     resolvePageComponent(`./Pages/${name}.jsx`, import.meta.glob('./Pages/**/*.jsx')),
   setup({ el, App, props }) {


### PR DESCRIPTION
## 概要

PR #195 で全ページのタイトルに `｜estion.` を直接追加しましたが、`app.jsx` の `title` コールバックも同時に適用されるため `xxx｜estion.｜estion.` と二重に表示される問題を修正しました。

## 変更内容

- `resources/js/app.jsx`: `title` コールバックを `(title) => \`${title}｜estion.\`` から `(title) => title`（そのまま返す）に変更
- `resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx`: `<Head title="ES作成">` → `<Head title="ES作成｜estion.">` に変更（コールバック経由のため `｜estion.` が付与されなくなることへの対応）

## 影響範囲

- 全ページのタブタイトル表示に影響（二重表示が解消される）
- `<Head title="...">` を使用しているページは `CreateForm` のみのため、他ページへの影響なし