### PR TITLE
fix: GeminiモデルをGemini 2.5 flashに更新

### DIFF
--- a/app/Http/Controllers/GeminiController.php
+++ b/app/Http/Controllers/GeminiController.php
@@ -130,7 +130,7 @@ class GeminiController extends Controller implements HasMiddleware
 
         $toGeminiCommand = "{$instruction}\n\n質問:\n{$question}\n\n回答:\n{$answer}";
 
-        $response = Gemini::generativeModel(model: 'gemini-2.0-flash')->generateContent($toGeminiCommand);
+        $response = Gemini::generativeModel(model: 'gemini-2.5-flash')->generateContent($toGeminiCommand);
         $rawResult = $response ? $response->text() : null;
 
         if ($rawResult === null) {


### PR DESCRIPTION
## 概要

Gemini APIで発生していたクォータ超過エラーを解消するため、使用モデルを `gemini-2.0-flash` から `gemini-2.5-flash` に変更しました。

## 変更内容

- `GeminiController.php` の `execute` メソッドで使用するモデルを変更
  - 変更前: `gemini-2.0-flash`
  - 変更後: `gemini-2.5-flash`

## 影響範囲

- AI模擬面接機能（`GeminiController@execute`）の挙動に影響します
- モデルが変わることでレスポンスの品質・フォーマットが若干変わる可能性があります
- `gemini-2.5-flash` のクォータ・レート制限が `gemini-2.0-flash` と異なる場合があるため、動作確認をお願いします