### PR TITLE
fix: ロゴリンクの不要なフォーカスリングスタイルを削除

### DIFF
--- a/resources/js/Pages/Auth/Login/index.jsx
+++ b/resources/js/Pages/Auth/Login/index.jsx
@@ -32,7 +32,7 @@ export default function Login() {
       <main className="flex min-h-screen flex-col items-center overflow-auto bg-gray-100 px-4 py-8 sm:justify-center">
         <Link
           href="/"
-          className="absolute left-8 top-6 z-10 text-4xl font-bold text-black transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-400"
+          className="absolute left-8 top-6 z-10 text-4xl font-bold text-black transition-opacity hover:opacity-80"
           aria-label="トップページへ戻る"
         >
           estion.


### PR DESCRIPTION
## 概要

Login画面のロゴリンクに追加されていたフォーカスリングスタイル (`focus:outline-none focus:ring-2 focus:ring-gray-400`) を削除しました。

## 変更内容

- `resources/js/Pages/Auth/Login/index.jsx`
  - ロゴリンク（`<Link href="/">`）の `className` から `focus:outline-none focus:ring-2 focus:ring-gray-400` を削除

## 影響範囲

- **対象ファイル**: `resources/js/Pages/Auth/Login/index.jsx` のみ
- **見た目への影響**: フォーカス時のグレーのリングが非表示になる
- **確認ポイント**:
  - ロゴリンクのフォーカス表示が意図した見た目になっているか
  - PR #200（Login画面リファクタリング）とのコンフリクトがないか