### PR TITLE
fix: パスワードバリデーション強化とOAuth CSRFプロテクション有効化

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -24,7 +24,7 @@ class LoginController extends Controller
 
     public function handleGoogleCallback()
     {
-        $googleUser = Socialite::driver('google')->stateless()->user();
+        $googleUser = Socialite::driver('google')->user();
 
         // 取得した Google ユーザー情報を確認
         // dd($googleUser);

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -32,7 +32,7 @@ class RegisteredUserController extends Controller
         $request->validate([
             'name' => 'required|string|max:255',
             'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
-            'password' => ['required', 'string', 'min:8', 'alpha_num', 'confirmed'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
 
         $user = User::create([

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -28,7 +28,7 @@ class LoginRequest extends FormRequest
     {
         return [
             'email' => ['required', 'string', 'email'],
-            'password' => ['required', 'string', 'min:8', 'alpha_num'],
+            'password' => ['required', 'string'],
         ];
     }
 


### PR DESCRIPTION
## 概要

セキュリティ診断で発見された2件の脆弱性を修正しました。パスワードバリデーションの不適切な制約の除去と、Google OAuth の CSRF 保護の有効化です。

## 変更内容

### パスワードバリデーションの修正

- **`LoginRequest.php`**: ログイン時のパスワードルールから `min:8` と `alpha_num` を削除
  - ログイン時にパスワード形式を検証すると、将来的なルール変更時に旧パスワードでログイン不能になるリスクがある
  - `required` + `string` のみに簡素化

- **`RegisteredUserController.php`**: 新規登録時のパスワードルールから `alpha_num` を削除
  - 英数字のみへの制限はパスワードエントロピーを大幅に低下させる（`!@#$%` などの記号が使用不可）
  - `min:8` + `confirmed` は維持し、特殊文字を含む強いパスワードを許容

### OAuth CSRF 保護の有効化

- **`LoginController.php`**: `Socialite::driver('google')->stateless()->user()` → `Socialite::driver('google')->user()`
  - `stateless()` は OAuth の `state` パラメータによる CSRF 検証を無効化していた
  - セッションベースの state 検証に戻すことで OAuth CSRF 攻撃を防止

## 影響範囲

- **確認ポイント**:
  - Google OAuth ログインフローが正常に動作するか（セッションが正しく機能しているか）
  - 既存ユーザーが記号を含まないパスワードでも引き続きログインできるか（`LoginRequest` のルール変更による影響）
  - 新規登録時に記号を含むパスワードが受け付けられるか
- **注意**: `LoginController.php` は PR #203（ログ削除）とも同一ファイルを変更しているため、マージ順序に注意してください