### PR TITLE
fix: google_access_token/refresh_tokenをシリアライズから除外

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,6 +35,8 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'google_access_token',
+        'google_refresh_token',
     ];
 
     /**


### PR DESCRIPTION
## 概要

`User` モデルの `$hidden` に `google_access_token` と `google_refresh_token` が含まれていなかったため、`toArray()` や JSON レスポンス時にトークンが漏洩する可能性がありました。

## 変更内容

- **`app/Models/User.php`**: `$hidden` に以下を追加
  - `google_access_token`
  - `google_refresh_token`

```php
protected $hidden = [
    'password',
    'remember_token',
    'google_access_token',   // 追加
    'google_refresh_token',  // 追加
];
```

## 影響範囲

- **対象ファイル**: `app/Models/User.php` のみ
- **動作への影響**: なし（トークンの読み書き自体は変わらず、シリアライズ時の出力から除外されるだけ）
- **確認ポイント**:
  - `$user->toArray()` や `$user->toJson()` の結果にトークンが含まれなくなることを確認
  - Google Calendar 連携など、トークンを `$user->google_access_token` で直接参照しているコードは引き続き動作することを確認（`$hidden` はプロパティアクセスには影響しない）