### PR TITLE
fix: LoginControllerのenv()をconfig()経由に変更

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -64,9 +64,9 @@ class LoginController extends Controller
         // Google カレンダー API の認証情報を取得
 
         $client = new Google_Client;
-        $client->setClientId(env('GOOGLE_CLIENT_ID'));
-        $client->setClientSecret(env('GOOGLE_CLIENT_SECRET'));
-        $client->setRedirectUri(env('GOOGLE_REDIRECT_URI'));
+        $client->setClientId(config('services.google.client_id'));
+        $client->setClientSecret(config('services.google.client_secret'));
+        $client->setRedirectUri(config('services.google.redirect'));
         // $client->addScope(Google_Service_Calendar::CALENDAR_READONLY);
         $client->setAccessToken($googleUser->token);
 


### PR DESCRIPTION
## 概要

`LoginController` 内で `Google_Client` の設定に `env()` を直接使用していました。`php artisan config:cache` 実行後は `env()` が常に `null` を返すため、`config()` 経由に変更しました。

## 変更内容

- **`app/Http/Controllers/Auth/LoginController.php`**
  - `env('GOOGLE_CLIENT_ID')` → `config('services.google.client_id')`
  - `env('GOOGLE_CLIENT_SECRET')` → `config('services.google.client_secret')`
  - `env('GOOGLE_REDIRECT_URI')` → `config('services.google.redirect')`

いずれも既存の `config/services.php` の `google` キーに定義済みの値を参照しています。

## 影響範囲

- **対象ファイル**: `app/Http/Controllers/Auth/LoginController.php` のみ
- **動作への影響**: 通常環境（キャッシュなし）では変わらず動作。`config:cache` 使用時に `null` になっていたバグが修正される
- **確認ポイント**:
  - Google OAuth ログインフローで `Google_Client` が正しくクライアントIDなどを取得できるか
  - `config/services.php` の `google.redirect` の値（`GOOGLE_REDIRECT_URL`）が `.env` の `GOOGLE_REDIRECT_URI` と一致しているか確認推奨