### PR TITLE
feat: ブックマーク編集機能を追加

### DIFF
--- a/app/Http/Controllers/BookmarkController.php
+++ b/app/Http/Controllers/BookmarkController.php
@@ -24,7 +24,7 @@ class BookmarkController extends Controller implements HasMiddleware
      */
     public function create()
     {
-        return Inertia::render('App/components/BookmarkCreate/index', [
+        return Inertia::render('Bookmark/Create', [
             'bookmarks' => Auth::check() ? Auth::user()->bookmark()->latest()->get() : [],
         ]);
     }
@@ -56,7 +56,13 @@ class BookmarkController extends Controller implements HasMiddleware
      */
     public function edit(Bookmark $bookmark)
     {
-        //
+        if ($bookmark->user_id !== Auth::id()) {
+            abort(403, 'このURLを編集する権限がありません。');
+        }
+
+        return Inertia::render('Bookmark/Edit/index', [
+            'bookmark' => $bookmark,
+        ]);
     }
 
     /**
@@ -64,7 +70,16 @@ class BookmarkController extends Controller implements HasMiddleware
      */
     public function update(UpdateBookmarkRequest $request, Bookmark $bookmark)
     {
-        //
+        if ($bookmark->user_id !== Auth::id()) {
+            abort(403, 'このURLを編集する権限がありません。');
+        }
+
+        $bookmark->update([
+            'name' => $request->name,
+            'url'  => $request->url,
+        ]);
+
+        return redirect()->route('bookmark.create')->with('success', 'お気に入りURLを更新しました');
     }
 
     /**

--- a/app/Http/Controllers/BookmarkController.php
+++ b/app/Http/Controllers/BookmarkController.php
@@ -76,7 +76,7 @@ class BookmarkController extends Controller implements HasMiddleware
 
         $bookmark->update([
             'name' => $request->name,
-            'url'  => $request->url,
+            'url' => $request->url,
         ]);
 
         return redirect()->route('bookmark.create')->with('success', 'お気に入りURLを更新しました');

--- a/app/Http/Requests/UpdateBookmarkRequest.php
+++ b/app/Http/Requests/UpdateBookmarkRequest.php
@@ -23,7 +23,7 @@ class UpdateBookmarkRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'url'  => 'required|url|max:255',
+            'url' => 'required|url|max:255',
         ];
     }
 }

--- a/app/Http/Requests/UpdateBookmarkRequest.php
+++ b/app/Http/Requests/UpdateBookmarkRequest.php
@@ -11,7 +11,7 @@ class UpdateBookmarkRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,8 @@ class UpdateBookmarkRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'name' => 'required|string|max:255',
+            'url'  => 'required|url|max:255',
         ];
     }
 }

--- a/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
@@ -33,7 +33,7 @@ export function BookmarkIndex({ bookmarks }) {
                   {bookmark.name}
                 </a>
               </div>
-              <div className="flex shrink-0 items-center gap-3 ml-4">
+              <div className="ml-4 flex shrink-0 items-center gap-3">
                 <button
                   type="button"
                   onClick={() => router.visit(route('bookmark.edit', bookmark.id))}

--- a/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
@@ -1,4 +1,5 @@
-import { useForm } from '@inertiajs/react';
+import { router, useForm } from '@inertiajs/react';
+import { icons } from '@/Utils/icons';
 
 export function BookmarkIndex({ bookmarks }) {
   const { delete: destroy } = useForm({});
@@ -32,13 +33,20 @@ export function BookmarkIndex({ bookmarks }) {
                   {bookmark.name}
                 </a>
               </div>
-              <button
-                type="button"
-                onClick={() => handleDelete(bookmark.id)}
-                className="ml-4 rounded-md text-red-600 hover:text-red-800 focus:outline-none"
-              >
-                削除
-              </button>
+              <div className="flex shrink-0 items-center gap-3 ml-4">
+                <button
+                  type="button"
+                  onClick={() => router.visit(route('bookmark.edit', bookmark.id))}
+                  className="text-blue-600 hover:text-blue-800 focus:outline-none"
+                  dangerouslySetInnerHTML={{ __html: icons.edit_mini }}
+                />
+                <button
+                  type="button"
+                  onClick={() => handleDelete(bookmark.id)}
+                  className="text-red-600 hover:text-red-800 focus:outline-none"
+                  dangerouslySetInnerHTML={{ __html: icons.trash_mini }}
+                />
+              </div>
             </li>
           ))}
         </ul>

--- a/resources/js/Pages/Bookmark/Edit/index.jsx
+++ b/resources/js/Pages/Bookmark/Edit/index.jsx
@@ -1,0 +1,99 @@
+import { AppLayout } from '@/Layouts/AppLayout';
+import { Head, Link, useForm } from '@inertiajs/react';
+
+export default function Edit({ bookmark }) {
+  const { data, setData, put, processing, errors } = useForm({
+    name: bookmark.name,
+    url: bookmark.url,
+  });
+
+  const handleChange = (event) => {
+    setData(event.target.name, event.target.value);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    put(route('bookmark.update', bookmark.id));
+  };
+
+  return (
+    <AppLayout>
+      <Head>
+        <title>ブックマーク編集｜estion.</title>
+        <meta
+          name="description"
+          content="estion.のブックマーク編集ページです。登録したお気に入りURLの名称・URLを編集することができます。"
+        />
+        <meta name="google-adsense-account" content="ca-pub-9604843985307640" />
+        <script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9604843985307640"
+          crossOrigin="anonymous"
+        ></script>
+      </Head>
+      <div className="mx-auto max-w-4xl px-6 py-12">
+        <h2 className="mb-6 text-2xl font-bold text-gray-800">ブックマーク編集</h2>
+
+        {Object.keys(errors).length > 0 && (
+          <div className="mb-4 rounded-[12px] bg-red-100 p-4 text-red-700">
+            <ul>
+              {Object.values(errors).map((error, index) => (
+                <li key={index}>{error}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="rounded-[12px] border bg-white p-6">
+          <form onSubmit={handleSubmit}>
+            <div className="mb-4">
+              <label htmlFor="name" className="mb-2 block font-bold text-gray-700">
+                サイト名
+              </label>
+              <input
+                type="text"
+                name="name"
+                id="name"
+                value={data.name}
+                onChange={handleChange}
+                className="w-full rounded-[12px] border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-blue-500"
+                required
+              />
+            </div>
+
+            <div className="mb-4">
+              <label htmlFor="url" className="mb-2 block font-bold text-gray-700">
+                URL
+              </label>
+              <input
+                type="url"
+                name="url"
+                id="url"
+                value={data.url}
+                onChange={handleChange}
+                className="w-full rounded-[12px] border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-blue-500"
+                required
+              />
+            </div>
+
+            <div className="flex items-center justify-end gap-4">
+              <Link
+                href={route('bookmark.create')}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                戻る
+              </Link>
+              <button
+                type="submit"
+                className="rounded-[12px] bg-blue-600 px-6 py-3 text-white hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                disabled={processing}
+              >
+                更新
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/resources/js/Pages/Bookmark/Edit/index.jsx
+++ b/resources/js/Pages/Bookmark/Edit/index.jsx
@@ -77,10 +77,7 @@ export default function Edit({ bookmark }) {
             </div>
 
             <div className="flex items-center justify-end gap-4">
-              <Link
-                href={route('bookmark.create')}
-                className="text-gray-500 hover:text-gray-700"
-              >
+              <Link href={route('bookmark.create')} className="text-gray-500 hover:text-gray-700">
                 戻る
               </Link>
               <button

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -22,6 +22,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Bookmark
     Route::get('/bookmark/create', [BookmarkController::class, 'create'])->name('bookmark.create');
     Route::post('/bookmark', [BookmarkController::class, 'store'])->name('bookmark.store');
+    Route::get('/bookmark/{bookmark}/edit', [BookmarkController::class, 'edit'])->name('bookmark.edit');
+    Route::put('/bookmark/{bookmark}', [BookmarkController::class, 'update'])->name('bookmark.update');
     Route::delete('/bookmark/{bookmark}', [BookmarkController::class, 'destroy'])->name('bookmark.destroy');
 
     // Analysis


### PR DESCRIPTION
<img width="1470" height="797" alt="image" src="https://github.com/user-attachments/assets/b3fb5772-c68c-49dd-96b2-2b62e0ac9200" />

<img width="1470" height="798" alt="image" src="https://github.com/user-attachments/assets/20e79ad9-2347-48ea-85d1-1bb1f7b0a8ef" />


## 概要
ブックマークの名称・URLを編集できる機能が未実装だったため、Company/Entrysheet の既存パターンを踏襲して実装した。
あわせて、`BookmarkCreate` コンポーネントが named export になっておりページが表示されないバグを修正した。

## 変更内容

### Backend
- **`routes/dashboard.php`**: `GET /bookmark/{bookmark}/edit`・`PUT /bookmark/{bookmark}` ルートを追加
- **`BookmarkController.php`**: `edit()` / `update()` を実装。所有者以外のアクセスは 403 で拒否
- **`UpdateBookmarkRequest.php`**: `authorize()` を `true` に変更、`name` / `url` のバリデーションルールを追加

### Frontend
- **`Bookmark/Edit/index.jsx`** (新規): サイト名・URL の入力フォームと更新・戻るボタンを持つ編集ページ
- **`BookmarkCreate/index.jsx`**: `export function` → `export default function` に修正（Inertia のページ解決バグ修正）
- **`BookmarkIndex/index.jsx`**: 削除ボタンをアイコン化し、編集アイコンボタンを追加（`icons.edit_mini` / `icons.trash_mini` を使用）

## 影響範囲
- `/bookmark/create` のブックマーク一覧 UI が変わる（削除ボタンがアイコンに、編集アイコンが追加）
- `BookmarkCreate` の export 変更により、このコンポーネントを named import している箇所がないことを確認済み
- 他ユーザーのブックマークへのアクセスは 403 を返すため、認可漏れはない