### PR TITLE
feat: ブックマーク並べ替え機能を追加

### DIFF
--- a/app/Http/Controllers/BookmarkController.php
+++ b/app/Http/Controllers/BookmarkController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreBookmarkRequest;
 use App\Http\Requests\UpdateBookmarkRequest;
 use App\Models\Bookmark;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
@@ -25,7 +26,7 @@ class BookmarkController extends Controller implements HasMiddleware
     public function create()
     {
         return Inertia::render('Bookmark/Create', [
-            'bookmarks' => Auth::check() ? Auth::user()->bookmark()->latest()->get() : [],
+            'bookmarks' => Auth::check() ? Auth::user()->bookmark()->orderBy('order')->get() : [],
         ]);
     }
 
@@ -94,6 +95,18 @@ class BookmarkController extends Controller implements HasMiddleware
         $bookmark->delete();
 
         return redirect()->route('bookmark.create')->with('success', 'お気に入りURLを削除しました！');
+    }
+
+    public function reorder(Request $request)
+    {
+        $ids = $request->input('ids', []);
+        foreach ($ids as $index => $id) {
+            Bookmark::where('id', $id)
+                ->where('user_id', Auth::id())
+                ->update(['order' => $index]);
+        }
+
+        return response()->noContent();
     }
 
     public static function middleware(): array

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -13,7 +13,7 @@ class DashboardController extends Controller
         $user = Auth::user();
 
         // ログインユーザーに紐づくエントリーシートとブックマークを取得
-        $bookmarks = $user->bookmark()->get();
+        $bookmarks = $user->bookmark()->orderBy('order')->get();
         // ログインユーザーに紐づく業界のみ取得
         $industries = $user->industries()->get();
         // 締切間近ES取得

--- a/app/Models/Bookmark.php
+++ b/app/Models/Bookmark.php
@@ -12,7 +12,7 @@ class Bookmark extends Model
     /** @use HasFactory<\Database\Factories\BookmarkFactory> */
     use HasFactory, SoftDeletes;
 
-    protected $fillable = ['name', 'url', 'user_id'];
+    protected $fillable = ['name', 'url', 'user_id', 'order'];
 
     public function user(): BelongsTo
     {

--- a/database/migrations/2026_02_26_014228_add_order_to_bookmarks_table.php
+++ b/database/migrations/2026_02_26_014228_add_order_to_bookmarks_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bookmarks', function (Blueprint $table) {
+            $table->integer('order')->default(0)->after('url');
+        });
+
+        // 既存レコードに初期順序を設定（ユーザーごと・作成日時順）
+        $users = DB::table('users')->pluck('id');
+        foreach ($users as $userId) {
+            $ids = DB::table('bookmarks')
+                ->where('user_id', $userId)
+                ->whereNull('deleted_at')
+                ->orderBy('created_at')
+                ->pluck('id');
+            foreach ($ids as $index => $id) {
+                DB::table('bookmarks')->where('id', $id)->update(['order' => $index]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bookmarks', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
     "packages": {
         "": {
             "dependencies": {
+                "@dnd-kit/core": "^6.3.1",
+                "@dnd-kit/sortable": "^10.0.0",
+                "@dnd-kit/utilities": "^3.2.2",
                 "react-textarea-autosize": "^8.5.9"
             },
             "devDependencies": {
@@ -357,6 +360,59 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@dnd-kit/accessibility": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+            "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/core": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+            "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/accessibility": "^3.1.1",
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/sortable": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+            "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@dnd-kit/core": "^6.3.0",
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/utilities": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+            "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -5517,7 +5573,6 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -5812,7 +5867,6 @@
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -6476,7 +6530,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
             "license": "0BSD"
         },
         "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
         "vite": "^6.0"
     },
     "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "react-textarea-autosize": "^8.5.9"
     }
 }

--- a/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
@@ -68,7 +68,7 @@ export function BookmarkIndex({ bookmarks: initialBookmarks }) {
 
   const sensors = useSensors(
     useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
   const handleDelete = (id) => {
@@ -96,11 +96,7 @@ export function BookmarkIndex({ bookmarks: initialBookmarks }) {
     <div className="mt-8 overflow-hidden rounded-[12px] border bg-white p-8">
       <h2 className="mb-6 text-2xl font-bold">登録されたURL一覧</h2>
       {bookmarks && bookmarks.length > 0 ? (
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleDragEnd}
-        >
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext
             items={bookmarks.map((b) => b.id)}
             strategy={verticalListSortingStrategy}

--- a/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
@@ -1,8 +1,75 @@
+import { useState } from 'react';
+import axios from 'axios';
 import { router, useForm } from '@inertiajs/react';
 import { icons } from '@/Utils/icons';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
-export function BookmarkIndex({ bookmarks }) {
+function SortableBookmarkItem({ bookmark, onDelete }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: bookmark.id,
+  });
+  const style = { transform: CSS.Transform.toString(transform), transition };
+
+  return (
+    <li ref={setNodeRef} style={style} className="flex items-center justify-between py-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          {...attributes}
+          {...listeners}
+          className="shrink-0 cursor-grab text-gray-400 hover:text-gray-600 active:cursor-grabbing"
+        >
+          ⠿
+        </span>
+        <a
+          href={bookmark.url}
+          className="truncate font-bold text-blue-500 hover:text-blue-800"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {bookmark.name}
+        </a>
+      </div>
+      <div className="ml-4 flex shrink-0 items-center gap-3">
+        <button
+          type="button"
+          onClick={() => router.visit(route('bookmark.edit', bookmark.id))}
+          className="text-blue-600 hover:text-blue-800 focus:outline-none"
+          dangerouslySetInnerHTML={{ __html: icons.edit_mini }}
+        />
+        <button
+          type="button"
+          onClick={() => onDelete(bookmark.id)}
+          className="text-red-600 hover:text-red-800 focus:outline-none"
+          dangerouslySetInnerHTML={{ __html: icons.trash_mini }}
+        />
+      </div>
+    </li>
+  );
+}
+
+export function BookmarkIndex({ bookmarks: initialBookmarks }) {
+  const [bookmarks, setBookmarks] = useState(initialBookmarks);
   const { delete: destroy } = useForm({});
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   const handleDelete = (id) => {
     if (confirm('本当にこのURLを削除しますか？')) {
@@ -16,40 +83,39 @@ export function BookmarkIndex({ bookmarks }) {
     }
   };
 
+  const handleDragEnd = ({ active, over }) => {
+    if (!over || active.id === over.id) return;
+    const oldIndex = bookmarks.findIndex((b) => b.id === active.id);
+    const newIndex = bookmarks.findIndex((b) => b.id === over.id);
+    const newOrder = arrayMove(bookmarks, oldIndex, newIndex);
+    setBookmarks(newOrder);
+    axios.patch(route('bookmark.reorder'), { ids: newOrder.map((b) => b.id) });
+  };
+
   return (
     <div className="mt-8 overflow-hidden rounded-[12px] border bg-white p-8">
       <h2 className="mb-6 text-2xl font-bold">登録されたURL一覧</h2>
       {bookmarks && bookmarks.length > 0 ? (
-        <ul>
-          {bookmarks.map((bookmark) => (
-            <li key={bookmark.id} className="flex items-center justify-between py-3">
-              <div className="truncate">
-                <a
-                  href={bookmark.url}
-                  className="block py-1 font-bold text-blue-500 hover:text-blue-800"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {bookmark.name}
-                </a>
-              </div>
-              <div className="ml-4 flex shrink-0 items-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => router.visit(route('bookmark.edit', bookmark.id))}
-                  className="text-blue-600 hover:text-blue-800 focus:outline-none"
-                  dangerouslySetInnerHTML={{ __html: icons.edit_mini }}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={bookmarks.map((b) => b.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul>
+              {bookmarks.map((bookmark) => (
+                <SortableBookmarkItem
+                  key={bookmark.id}
+                  bookmark={bookmark}
+                  onDelete={handleDelete}
                 />
-                <button
-                  type="button"
-                  onClick={() => handleDelete(bookmark.id)}
-                  className="text-red-600 hover:text-red-800 focus:outline-none"
-                  dangerouslySetInnerHTML={{ __html: icons.trash_mini }}
-                />
-              </div>
-            </li>
-          ))}
-        </ul>
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
       ) : (
         <p className="text-gray-500">登録されたURLはありません。</p>
       )}

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -21,6 +21,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Bookmark
     Route::get('/bookmark/create', [BookmarkController::class, 'create'])->name('bookmark.create');
+    Route::patch('/bookmarks/reorder', [BookmarkController::class, 'reorder'])->name('bookmark.reorder');
     Route::post('/bookmark', [BookmarkController::class, 'store'])->name('bookmark.store');
     Route::get('/bookmark/{bookmark}/edit', [BookmarkController::class, 'edit'])->name('bookmark.edit');
     Route::put('/bookmark/{bookmark}', [BookmarkController::class, 'update'])->name('bookmark.update');


### PR DESCRIPTION
## 概要
ブックマーク一覧にドラッグ&ドロップによる並べ替え機能を追加する。変更した順番はDBに永続化され、ナビバーの先頭3件表示にも反映される。

## 変更内容
### Backend
- **`database/migrations/..._add_order_to_bookmarks_table.php`** （新規）: `bookmarks` テーブルに `order` カラムを追加。マイグレーション実行時に既存レコードへ作成日時順で初期値を設定
- **`app/Models/Bookmark.php`**: `$fillable` に `order` を追加
- **`app/Http/Controllers/BookmarkController.php`**:
  - `create()` の取得順を `latest()` → `orderBy('order')` に変更
  - `reorder(Request $request)` メソッドを追加（`PATCH /bookmarks/reorder`）
- **`app/Http/Controllers/DashboardController.php`**: ブックマーク取得を `orderBy('order')` に変更（ナビバー反映）
- **`routes/dashboard.php`**: `PATCH /bookmarks/reorder` ルートを追加

### Frontend
- **`resources/js/Pages/Bookmark/BookmarkIndex/index.jsx`**: `@dnd-kit/sortable` によるD&D並べ替えを実装
  - 各アイテム左端にドラッグハンドル（`⠿`）を表示
  - ドラッグ終了時に楽観的UIでローカルstate更新 → `axios.patch` でバックグラウンド保存
  - `router.patch`（Inertiaナビゲーション）ではなく `axios.patch` を使用し、画面フラッシュを防止

### パッケージ
- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` を追加

## 影響範囲
- **ナビバーのブックマーク表示順**: `DashboardController` と `BookmarkController` の両方で `orderBy('order')` に統一されているため、並べ替え後はどのページのナビバーにも反映される
- **セキュリティ**: `reorder()` は `where('user_id', Auth::id())` でフィルタリングしており、他ユーザーのIDを含むリクエストは無視される
- **既存データ**: マイグレーションで既存レコードに `order` 初期値が設定されるため、データの欠損は発生しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)