### PR TITLE
fix: ブックマーク追加・並べ替え時のリアルタイム反映を修正

### DIFF
--- a/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
@@ -93,11 +93,9 @@ export function BookmarkIndex({ bookmarks: initialBookmarks }) {
     const newIndex = bookmarks.findIndex((b) => b.id === over.id);
     const newOrder = arrayMove(bookmarks, oldIndex, newIndex);
     setBookmarks(newOrder);
-    axios
-      .patch(route('bookmark.reorder'), { ids: newOrder.map((b) => b.id) })
-      .then(() => {
-        router.reload({ only: ['bookmarks'], preserveScroll: true, preserveState: true });
-      });
+    axios.patch(route('bookmark.reorder'), { ids: newOrder.map((b) => b.id) }).then(() => {
+      router.reload({ only: ['bookmarks'], preserveScroll: true, preserveState: true });
+    });
   };
 
   return (

--- a/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
+++ b/resources/js/Pages/Bookmark/BookmarkIndex/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { router, useForm } from '@inertiajs/react';
 import { icons } from '@/Utils/icons';
@@ -66,6 +66,10 @@ export function BookmarkIndex({ bookmarks: initialBookmarks }) {
   const [bookmarks, setBookmarks] = useState(initialBookmarks);
   const { delete: destroy } = useForm({});
 
+  useEffect(() => {
+    setBookmarks(initialBookmarks);
+  }, [initialBookmarks]);
+
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
@@ -89,7 +93,11 @@ export function BookmarkIndex({ bookmarks: initialBookmarks }) {
     const newIndex = bookmarks.findIndex((b) => b.id === over.id);
     const newOrder = arrayMove(bookmarks, oldIndex, newIndex);
     setBookmarks(newOrder);
-    axios.patch(route('bookmark.reorder'), { ids: newOrder.map((b) => b.id) });
+    axios
+      .patch(route('bookmark.reorder'), { ids: newOrder.map((b) => b.id) })
+      .then(() => {
+        router.reload({ only: ['bookmarks'], preserveScroll: true, preserveState: true });
+      });
   };
 
   return (


### PR DESCRIPTION
## 概要
ブックマーク追加・削除後に一覧が更新されない問題と、並べ替え後にナビバーへ即時反映されない問題を修正する。

## 変更内容
**`resources/js/Pages/Bookmark/BookmarkIndex/index.jsx`**

- `useEffect` を追加し、Inertiaがサーバーから新しい `bookmarks` propsを渡すたびにローカルstateを同期するようにした
  - `useState(initialBookmarks)` はマウント時の値しか参照しないため、追加・削除後にInertiaがpropsを更新しても一覧に反映されていなかった
- 並べ替え後の `axios.patch` に `.then()` を追加し、DB保存成功後に `router.reload({ only: ['bookmarks'] })` で部分リロードを実行するようにした
  - これにより `usePage().props.bookmarks` が更新され、ナビバーの表示順がページリロードなしで即時反映される

## 影響範囲
- `preserveState: true` を指定しているため、部分リロード時にリストのローカルstateはリセットされず、視覚的なちらつきは発生しない
- `preserveScroll: true` によりスクロール位置も維持される
- ナビバーの更新タイミングはDB保存完了後（axios成功後）になるため、楽観的UIのリスト更新とは数百ms程度のずれが生じる可能性があるが、実用上は問題ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)