### PR TITLE
style: ブックマーク登録フォームの入力欄の高さを縮小

### DIFF
--- a/resources/js/Pages/Bookmark/Create.jsx
+++ b/resources/js/Pages/Bookmark/Create.jsx
@@ -61,7 +61,7 @@ export default function Create({ bookmarks }) {
                 name="name"
                 value={data.name}
                 onChange={handleChange}
-                className="w-full rounded-[12px] border border-gray-300 p-3 focus:border-blue-500 focus:ring-blue-500"
+                className="w-full rounded-[12px] border border-gray-300 p-2 focus:border-blue-500 focus:ring-blue-500"
                 required
               />
             </div>
@@ -76,7 +76,7 @@ export default function Create({ bookmarks }) {
                 name="url"
                 value={data.url}
                 onChange={handleChange}
-                className="w-full rounded-[12px] border border-gray-300 p-3 focus:border-blue-500 focus:ring-blue-500"
+                className="w-full rounded-[12px] border border-gray-300 p-2 focus:border-blue-500 focus:ring-blue-500"
                 required
               />
             </div>


### PR DESCRIPTION
## 概要
ブックマーク登録フォームのサイト名・URL入力欄が大きすぎるため、paddingを調整してコンパクトにする。

## 変更内容
- **`resources/js/Pages/Bookmark/Create.jsx`**: サイト名・URL の `<input>` の `className` 内 `p-3` → `p-2` に変更

## 影響範囲
- ブックマーク登録ページ（`/bookmark/create`）のフォーム表示のみに影響
- 機能・ロジックの変更はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)