### PR TITLE
fix: 新規ブックマークを末尾に追加するよう修正

### DIFF
--- a/app/Http/Controllers/BookmarkController.php
+++ b/app/Http/Controllers/BookmarkController.php
@@ -35,10 +35,13 @@ class BookmarkController extends Controller implements HasMiddleware
      */
     public function store(StoreBookmarkRequest $request)
     {
+        $maxOrder = Bookmark::where('user_id', Auth::id())->max('order') ?? -1;
+
         Bookmark::create([
             'name' => $request->name,
             'url' => $request->url,
             'user_id' => Auth::id(),
+            'order' => $maxOrder + 1,
         ]);
 
         return redirect()->route('bookmark.create')->with('success', 'お気に入りURLを追加しました');


### PR DESCRIPTION
## 概要
ブックマーク新規追加時に `order` を指定していなかったため、デフォルト値 `0` が設定され並べ替え後も先頭に挿入されてしまう問題を修正する。

## 変更内容
- **`app/Http/Controllers/BookmarkController.php`** の `store()` メソッドを修正
  - 登録前にログインユーザーの `max('order')` を取得し、`+1` した値を `order` に設定
  - ブックマークが1件もない場合は `max()` が `null` を返すため `?? -1` でフォールバックし、最初の1件の `order` が `0` になるよう保証

## 影響範囲
- ブックマーク新規追加時のDBへの書き込みのみに影響
- 既存レコードへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)