### PR TITLE
feat: ナビバーのブックマーク表示数を増やし横スクロールに対応

### DIFF
--- a/resources/js/Layouts/NavBar/Bookmark/index.jsx
+++ b/resources/js/Layouts/NavBar/Bookmark/index.jsx
@@ -1,23 +1,27 @@
 import React from 'react';
 
 export function Bookmark({ bookmarks }) {
+  if (!bookmarks || bookmarks.length === 0) return null;
+
   return (
-    <div className="flex space-x-6 text-sm font-medium text-gray-600">
-      {bookmarks && bookmarks.length > 0 && <span className="font-medium text-gray-600">|</span>}
-      {bookmarks &&
-        bookmarks.length > 0 &&
-        bookmarks.slice(0, 3).map((bookmark) => (
-          <React.Fragment key={bookmark.id}>
-            <a
-              href={bookmark.url}
-              className="hover:text-gray-900"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {bookmark.name}
-            </a>
-          </React.Fragment>
+    <div className="flex items-center gap-6 text-sm font-medium text-gray-600">
+      <span>|</span>
+      <div
+        className="flex max-w-[360px] gap-6 overflow-x-auto [&::-webkit-scrollbar]:hidden"
+        style={{ scrollbarWidth: 'none' }}
+      >
+        {bookmarks.map((bookmark) => (
+          <a
+            key={bookmark.id}
+            href={bookmark.url}
+            className="shrink-0 hover:text-gray-900"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {bookmark.name}
+          </a>
         ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
ナビバーのブックマーク表示を3件固定から全件表示に変更し、5件程度が収まる横スクロールコンテナを実装する。

## 変更内容
**`resources/js/Layouts/NavBar/Bookmark/index.jsx`**
- `bookmarks.slice(0, 3)` を削除し、登録済みの全ブックマークを表示するよう変更
- ブックマークリンクを `max-w-[360px]` + `overflow-x-auto` のコンテナで囲み、5件程度を表示しつつそれ以上はスクロールで閲覧可能に
- 各リンクに `shrink-0` を付与し、スクロール時にテキストが潰れないよう対処
- `scrollbarWidth: none` / `[&::-webkit-scrollbar]:hidden` でスクロールバーを非表示にしてナビバーの見た目を維持
- `bookmarks` が空の場合は `null` を早期 return するようリファクタリング

## 影響範囲
- ナビバーのブックマーク表示部分のみに影響
- `max-w-[360px]` はブックマーク名の長さによって体感が変わるため、必要に応じて調整が必要