### PR TITLE
fix: ナビバー上でブックマークスクロールする際のマウス判定の高さを修正

### DIFF
--- a/resources/js/Layouts/NavBar/Bookmark/index.jsx
+++ b/resources/js/Layouts/NavBar/Bookmark/index.jsx
@@ -7,7 +7,7 @@ export function Bookmark({ bookmarks }) {
     <div className="flex items-center gap-6 text-sm font-medium text-gray-600">
       <span>|</span>
       <div
-        className="flex max-w-[360px] gap-6 overflow-x-auto [&::-webkit-scrollbar]:hidden"
+        className="flex max-w-[250px] items-center gap-6 overflow-x-auto py-2 [&::-webkit-scrollbar]:hidden"
         style={{ scrollbarWidth: 'none' }}
       >
         {bookmarks.map((bookmark) => (

--- a/resources/js/Layouts/NavBar/index.jsx
+++ b/resources/js/Layouts/NavBar/index.jsx
@@ -6,7 +6,7 @@ import { Bookmark } from './Bookmark';
 export function NavBar() {
   const { bookmarks } = usePage().props;
   return (
-    <nav className="fixed left-1/2 top-4 z-50 mx-auto w-full max-w-[95%] -translate-x-1/2 transform rounded-[12px] bg-white px-6 py-3 shadow">
+    <nav className="fixed left-1/2 top-4 z-50 mx-auto w-full max-w-[95%] -translate-x-1/2 transform rounded-[12px] bg-white px-6 py-1 shadow">
       <div className="flex items-center justify-between">
         <Link href="/dashboard" className="text-xl font-bold text-black">
           estion.


### PR DESCRIPTION
## 概要
- ナビバー上でスクロールする際の高さの有効範囲が狭かったのでスクロールしやすくなるように有効範囲を拡大
- 有効範囲を広くしないとスクロールした際にブラウザバックしてしまうため実装

## 変更内容
- ナビバーの高さ