### PR TITLE
fix: CreateFormをnamed exportからdefault exportに修正

### DIFF
--- a/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/CreateForm/index.jsx
@@ -3,7 +3,7 @@ import { useForm } from '@inertiajs/react';
 import { icons } from '@/Utils/icons';
 import { Head } from '@inertiajs/react';
 
-export function CreateForm({ industries, company: selectedCompany, presetTitles }) {
+export default function CreateForm({ industries, company: selectedCompany, presetTitles }) {
   const { data, setData, post, processing, errors } = useForm({
     company_id: selectedCompany?.id ?? '',
     title: '',

--- a/resources/js/Pages/App/Entrysheet/Create/CreateWithCompany.jsx
+++ b/resources/js/Pages/App/Entrysheet/Create/CreateWithCompany.jsx
@@ -1,5 +1,5 @@
 import { AppLayout } from '@/Layouts/AppLayout';
-import { CreateForm } from './CreateForm';
+import CreateForm from './CreateForm';
 
 export default function CreateWithCompany({ industries, company, presetTitles }) {
   return (


### PR DESCRIPTION
## 概要

Herokuへのデプロイ時にビルドエラーが発生していた問題を修正します。
`CreateForm/index.jsx` が named export になっているにもかかわらず、呼び出し側で default import していたことが原因です。

## 変更内容

- `CreateForm/index.jsx`: `export function CreateForm` → `export default function CreateForm` に変更
- `CreateWithCompany.jsx`: `import { CreateForm }` → `import CreateForm` に変更（named import → default import に統一）

## 影響範囲

- `CreateForm` コンポーネントを使用している2ファイル（`Create/index.jsx`、`CreateWithCompany.jsx`）に影響します
- コンポーネントの動作・UIへの変更はなく、export形式のみの修正です
- ローカル環境ではViteが名前解決を緩く行うためエラーが出ないケースがあり、Rollupによる本番ビルド（Heroku）でのみ表面化していました