### PR TITLE
docs: /prコマンドにJiraタスクキーを含むブランチ命名規則を追加

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,4 +1,24 @@
 プルリクエストの作成
+
+## ブランチ作成（mainブランチにいる場合）
+
+現在 `main` ブランチにいる場合は、作業用ブランチを作成してからコミット・PRを行うこと。
+ブランチ名は以下の形式で作成すること：
+
+```
+{type}/{JIRA-KEY}-{kebab-case-description}
+```
+
+- `{type}`: 変更種別（`feat` / `fix` / `refactor` / `chore` など）
+- `{JIRA-KEY}`: JiraのタスクキーをAskUserQuestionツールで必ずユーザーに確認すること（例: `KAN-7`）
+- `{kebab-case-description}`: 変更内容を表す短い英語の説明（ケバブケース）
+
+例: `feat/KAN-7-industry-modal`, `fix/KAN-12-login-error`
+
+ユーザーへの確認方法：AskUserQuestionツールを使い「JiraのタスクキーはなんですかText入力で答えてください」と聞くこと。
+
+---
+
 現在のブランチの変更内容（`git log` や `git diff`）を確認し、適切なPull RequestのタイトルとDescription（説明文）を自動生成してください。
 その後、GitHub CLI (`gh pr create`) を使用して実際にPRを作成してください。
 


### PR DESCRIPTION
## 概要

`/pr` スキル（`.claude/commands/pr.md`）に、mainブランチからPR作成時のブランチ命名規則を追加しました。ブランチ名にJiraのタスクキーを含めることでタスクとコードの紐付けを明確にします。

## 変更内容

- `.claude/commands/pr.md` に「ブランチ作成」セクションを追加
- ブランチ名の形式を `{type}/{JIRA-KEY}-{kebab-case-description}` と定義
- `AskUserQuestion` ツールでJiraタスクキーをユーザーに確認する手順を明記

## 影響範囲

- `/pr` コマンドの動作にのみ影響します
- 既存のコードや機能への影響はありません
- タスクキーなしでもPR作成できるよう選択肢を設けています