### PR TITLE
refactor: ナビゲーションの内部リンクをInertia Linkコンポーネントに変更

### DIFF
--- a/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
+++ b/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
@@ -1,3 +1,5 @@
+import { Link } from "@inertiajs/react";
+
 export function NavLinks() {
   return (
     <div className="hidden font-bold sm:flex sm:space-x-7 sm:pr-5 sm:text-[16px] md:space-x-12 md:text-[20px]">
@@ -9,12 +11,12 @@ export function NavLinks() {
       >
         お問い合わせ
       </a>
-      <a href="/login" className="text-black transition hover:text-gray-300">
+      <Link href="/login" className="text-black transition hover:text-gray-300">
         ログイン
-      </a>
-      <a href="/register" className="text-black transition hover:text-gray-300">
+      </Link>
+      <Link href="/register" className="text-black transition hover:text-gray-300">
         新規登録
-      </a>
+      </Link>
     </div>
   );
 }

--- a/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
+++ b/resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx
@@ -1,4 +1,4 @@
-import { Link } from "@inertiajs/react";
+import { Link } from '@inertiajs/react';
 
 export function NavLinks() {
   return (


### PR DESCRIPTION
## 概要

ゲスト向けナビバーの内部リンク（ログイン・新規登録）を `<a>` タグから Inertia.js の `<Link>` コンポーネントに変更しました。

## 変更内容

- `resources/js/Pages/Guest/components/NavBar/NavLinks/index.jsx`
  - `@inertiajs/react` から `Link` をインポート
  - `/login` リンクを `<a href>` → `<Link href>` に変更
  - `/register` リンクを `<a href>` → `<Link href>` に変更
  - 外部URL（お問い合わせフォーム）は `<a target="_blank">` のまま維持

## 影響範囲

- ゲスト向けナビバーのログイン・新規登録リンクの挙動が SPA ナビゲーション（フルページリロードなし）に変わります
- 既存の見た目・スタイルへの影響はありません
- 外部リンクには変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)